### PR TITLE
Fixed case when waiter is the same process as one being registered

### DIFF
--- a/src/gproc_lib.erl
+++ b/src/gproc_lib.erl
@@ -159,8 +159,8 @@ await({T,C,_} = Key, WPid, {_Pid, Ref} = From) ->
 maybe_waiters(K, Pid, Value, T, Info) ->
     case ets:lookup(?TAB, {K,T}) of
         [{_, Waiters}] when is_list(Waiters) ->
-            ets:insert(?TAB, Info),
             notify_waiters(Waiters, K, Pid, Value),
+            ets:insert(?TAB, Info),
             true;
         [_] ->
             false


### PR DESCRIPTION
Consider the following commands given in the shell:

application:start(gproc).
gproc:nb_wait({n, l, somekey}).
gproc:reg({n, l, somekey}).
gproc:unreg({n, l, somekey}).

This will fail, because gproc:maybe_waiters firstly inserts key in the ETS ({{<0.43.0>,{n,l,somekey}},r}), then invokes notify_waiters which in turn removes the same row from the ETS (since the waiting and registering processes are the same). The patch simply changes the order of two invocations. Firstly it notifies the waiters, then it inserts the row into the ETS.
