### PR TITLE
Add modules listing to the app.src file

### DIFF
--- a/src/gproc.app.src
+++ b/src/gproc.app.src
@@ -10,6 +10,15 @@
   {registered, [ ] },
   %% NOTE: do not list applications which are load-only!
   {applications, [ kernel, stdlib ] },
+  {modules, [
+    gproc,
+    gproc_app,
+    gproc_dist,
+    gproc_init,
+    gproc_lib,
+    gproc_sup
+   ]
+  },
   {mod, {gproc_app, []} }
  ]
 }.


### PR DESCRIPTION
Newest rebar requires modules listing in the app file by default. Also, might be useful for OTP releases.
