### PR TITLE
Change deps URIs from git to https protocols

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,9 +1,9 @@
 %% -*- erlang -*-
 {erl_opts, [debug_info]}.
 {deps, [
-        {edown, ".*", {git, "git://github.com/esl/edown.git", "HEAD"}},
+        {edown, ".*", {git, "https://github.com/esl/edown.git", "HEAD"}},
         {gen_leader, ".*",
-         {git, "git://github.com/abecciu/gen_leader_revival.git", "HEAD"}}
+         {git, "https://github.com/abecciu/gen_leader_revival.git", "HEAD"}}
        ]}.
 {dialyzer_opts, [{warnings, [no_unused,
                              no_improper_lists, no_fun_app, no_match,


### PR DESCRIPTION
Some unfortunate users are behind restrictive firewalls
which block the git protocol. HTTPS on the other hand
works almost everywhere.
