### PR TITLE
Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,13 +25,15 @@ REBAR=$(shell which rebar || echo ./rebar)
 
 DIRS=src
 
-all: compile
+all: deps compile
 
 check: compile dialyzer
 
 compile:
 	$(REBAR) compile
 
+deps:
+	$(REBAR) get-deps
 
 clean:
 	$(REBAR) clean


### PR DESCRIPTION
First commit gets rid of the assumption that rebar is in path.  Specifically it will still work if "." is not part of path.

Second commit gets dependencies on basic make, which should be a program where you can do "git clone, make, use".
