### PR TITLE
Add send_to_key/2 to send a message and return the pid/s it went to

### DIFF
--- a/src/gproc.erl
+++ b/src/gproc.erl
@@ -97,6 +97,7 @@
          give_away/2,
          goodbye/0,
          send/2,
+         send_to_key/2,
 	 bcast/2, bcast/3,
          info/1, info/2,
 	 i/0,
@@ -1579,6 +1580,43 @@ send1({T,C,_} = Key, Msg) when C==l; C==g ->
             erlang:error(badarg)
     end;
 send1(_, _) ->
+    ?THROW_GPROC_ERROR(badarg).
+
+%% @spec (Key::key(), Msg::any()) -> pid() | [pid()].
+%%
+%% @doc Sends a message to the process, or processes, corresponding to Key.
+%%
+%% If Key belongs to a unique object (name or aggregated counter), this
+%% function will send a message to the corresponding process, or fail if there
+%% is no such process. If Key is for a non-unique object type (counter or
+%% property), Msg will be send to all processes that have such an object.
+%% It returns the pid or list of pids the Msg was sent to.
+%% @end
+%%
+send_to_key(Key, Msg) ->
+    ?CATCH_GPROC_ERROR(send_to_key1(Key, Msg), [Key, Msg]).
+
+send_to_key1({T,C,_} = Key, Msg) when C==l; C==g ->
+    if T == n orelse T == a ->
+            case ets:lookup(?TAB, {Key, T}) of
+                [{_, Pid, _}] ->
+                    Pid ! Msg,
+                    Pid;
+                _ ->
+                    ?THROW_GPROC_ERROR(badarg)
+            end;
+       T==p orelse T==c ->
+            %% BUG - if the key part contains select wildcards, we may end up
+            %% sending multiple messages to the same pid
+            Pids = lists:foldl(fun(Pid, Acc) ->
+                                       Pid ! Msg,
+                                       [Pid | Acc]
+                               end, [], lookup_pids(Key)),
+            lists:reverse(Pids);
+       true ->
+            erlang:error(badarg)
+    end;
+send_to_key1(_, _) ->
     ?THROW_GPROC_ERROR(badarg).
 
 %% @spec (Key::key(), Msg::any()) -> Msg


### PR DESCRIPTION
To use _gproc_ to register names using the _via_ mechanism that was recently added to OTP (`gen_server`, `gen_fsm`, `gen_event`) it must provide a `send/2` function with the following spec:

``` erlang
send(Name :: term(), Msg :: term()) -> pid().
```

Currently `gproc:send/2` returns the message that was sent and because of
that _gproc_ cannot be used as a drop-in name registry for OTP. This patch
adds the `sent_to_key/2` function to be able to implement a name registry
on top of _gproc_. The new function has the following spec:

``` erlang
send_to_key(Name :: term(), Msg :: term()) -> pid() | [pid()].
```

It will return the pid or list of pids the message was sent to.
