### PR TITLE
Kill useless eunit include

### DIFF
--- a/src/gproc.erl
+++ b/src/gproc.erl
@@ -152,7 +152,6 @@
 
 -include("gproc_int.hrl").
 -include("gproc.hrl").
--include_lib("eunit/include/eunit.hrl").
 
 -define(SERVER, ?MODULE).
 %%-define(l, l(?LINE)). % when activated, calls a traceable empty function


### PR DESCRIPTION
This lone include looks like a leftover, so I propose to remove it entirely.
