### PR TITLE
Do not let check_edown halt a build if init:get_plain_arguments() is empty

### DIFF
--- a/priv/check_edown.script
+++ b/priv/check_edown.script
@@ -4,7 +4,11 @@
 %% To build docs, call `rebar get-deps doc`
 %% Assumes that the rebar config is bound to CONFIG
 
-[_|Args] = init:get_plain_arguments().  % rebar 'commands' and options
+Args = case init:get_plain_arguments() of
+    [_|A] -> A;  % rebar 'commands' and options
+    _ -> []
+end.
+
 case lists:member("doc", Args) of
     false ->
 	{ok,C1} = file:script(filename:join(filename:dirname(SCRIPT),


### PR DESCRIPTION
This may happen in case if rebar is used as a library.
