### PR TITLE
Correct remove of globals on process DOWN

### DIFF
--- a/src/gproc_dist.erl
+++ b/src/gproc_dist.erl
@@ -237,7 +237,7 @@ handle_call(_, _, S, _) ->
     {reply, badarg, S}.
 
 handle_info({'DOWN', _MRef, process, Pid, _}, S) ->
-    ets:delete(?TAB, {{Pid, g}}),
+    ets:delete(?TAB, {Pid, g}),
     leader_cast({pid_is_DOWN, Pid}),
     {ok, S};
 handle_info(_, S) ->


### PR DESCRIPTION
This fix was helped to remove a memory leak.
The leak was always on slave nodes, leader was ok. I found that leader was removing globals differently in `pid_is_DOWN` cast message, so I decided that is should be the same in `handle_info({'DOWN', ...`

Already tested on production. Please take a look if everything correct.
