### PR TITLE
Support binaries in choice so gproc:i/0 works with Elixir's IEx.

### DIFF
--- a/src/gproc_info.erl
+++ b/src/gproc_info.erl
@@ -78,7 +78,11 @@ choice(F) ->
     case get_line('(c)ontinue (q)uit -->', "c\n") of
         "c\n" ->
             F();
+        <<"c\n">> ->
+            F();
         "q\n" ->
+            quit;
+        <<"q\n">> ->
             quit;
         _ ->
             choice(F)


### PR DESCRIPTION
Erlang supports configuring `standard_io` to return binaries, `gproc_info` doesn't support that.
