### PR TITLE
Fix case_clause

### DIFF
--- a/src/gproc_dist.erl
+++ b/src/gproc_dist.erl
@@ -736,7 +736,8 @@ remove_entry(Key, Pid, Event) ->
 	    remove_rev_entry(get_opts(Pid, Key), Pid, Key, Event);
 	[{_, _OtherPid, _}] ->
 	    ets:delete(?TAB, {Pid, Key}),
-	    []
+	    [];
+	[] -> []
     end.
 
 remove_rev_entry(Opts, Pid, {T,g,_} = K, Event) when T==n; T==a ->


### PR DESCRIPTION
I have this crash report:

```erlang
2014-12-17 14:45:53 =ERROR REPORT====
** Generic leader gproc_dist terminating 
** Last message in was {pid_is_DOWN,<0.1845.0>}
** When Server state == {state,false,true,[]}
** Reason for termination == 
** {{case_clause,[]},[{gproc_dist,remove_entry,3,[{file,"src/gproc_dist.erl"},{line,733}]},{gproc_dist,maybe_failover,4,[{file,"src/gproc_dist.erl"},{line,701}]},{lists,foldl,3,[{file,"lists.erl"},{line,1261}]},{gproc_dist,process_globals,1,[{file,"src/gproc_dist.erl"},{line,674}]},{gproc_dist,handle_leader_cast,3,[{file,"src/gproc_dist.erl"},{line,649}]},{gen_leader,handle_msg,4,[{file,"src/gen_leader.erl"},{line,1169}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,239}]}]}
2014-12-17 14:45:53 =CRASH REPORT====
  crasher:
    initial call: gen:init_it/7
    pid: <0.89.0>
    registered_name: gproc_dist
    exception exit: {{{case_clause,[]},[{gproc_dist,remove_entry,3,[{file,"src/gproc_dist.erl"},{line,733}]},{gproc_dist,maybe_failover,4,[{file,"src/gproc_dist.erl"},{line,701}]},{lists,foldl,3,[{file,"lists.erl"},{line,1261}]},{gproc_dist,process_globals,1,[{file,"src/gproc_dist.erl"},{line,674}]},{gproc_dist,handle_leader_cast,3,[{file,"src/gproc_dist.erl"},{line,649}]},{gen_leader,handle_msg,4,[{file,"src/gen_leader.erl"},{line,1169}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,239}]}]},[{gen_leader,terminate,5,[{file,"src/gen_leader.erl"},{line,1244}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,239}]}]}
    ancestors: [gproc_sup,<0.86.0>]
    messages: [{'$leader_call',{<0.15059.0>,#Ref<0.0.0.245347>},{reg,{n,g,{connection,3887}},undefined,<0.15059.0>}}]
    links: [<0.87.0>,<0.90.0>]
    dictionary: []
    trap_exit: false
    status: running
    heap_size: 987
    stack_size: 27
    reductions: 50898
  neighbours:
    neighbour: [{pid,<0.90.0>},{registered_name,[]},{initial_call,{gen_leader,'-spawn_monitor_proc/0-fun-0-',[]}},{current_function,{gen_leader,mon_loop,2}},{ancestors,[gproc_dist,gproc_sup,<0.86.0>]},{messages,[]},{links,[<0.89.0>]},{dictionary,[]},{trap_exit,false},{status,waiting},{heap_size,233},{stack_size,7},{reductions,10}]
```

I don't know how repeat this problem. But i made patch for fixes it.