### PR TITLE
Remove misleading comment in .app file

### DIFF
--- a/src/gproc.app.src
+++ b/src/gproc.app.src
@@ -8,7 +8,6 @@
   {vsn, git},
   {id, "GPROC"},
   {registered, [ ] },
-  %% NOTE: do not list applications which are load-only!
   {applications, [ kernel, stdlib ] },
   {mod, {gproc_app, []} }
  ]


### PR DESCRIPTION
The comment says don't list applications which are load only,
just above the line listing stdlib which is load only.

It is very misleading to newcomers so best to remove it.

Sorry for the tiniest change ever but gproc is used by tons of newcomers and I figure it's best to avoid confusing them when they see this. :-)