### PR TITLE
Uw intermittent test failures

### DIFF
--- a/src/gproc_dist.erl
+++ b/src/gproc_dist.erl
@@ -995,5 +995,5 @@ add_follow_to_waiters(Waiters, {T,_,_} = K, Pid, Ref, S) ->
             {reply, Ref, [{insert, [Obj, Rev]}], S};
        true ->
             {reply, Ref, [{insert, [Obj, Rev]},
-                          {notify, [{Pid, Msg}]}]}
+                          {notify, [{Pid, Msg}]}], S}
     end.

--- a/test/gproc_test_lib.erl
+++ b/test/gproc_test_lib.erl
@@ -127,7 +127,7 @@ got_msg(Pb, Tag) ->
 	    end}).
 
 t_pool_contains_atleast(Pool,N)->
-    Existing = lists:foldl(fun({X,Y},Acc)->
+    Existing = lists:foldl(fun({_X,_Y},Acc)->
                                    Acc+1;
                               (_,Acc) ->
                                    Acc

--- a/test/gproc_tests.erl
+++ b/test/gproc_tests.erl
@@ -795,8 +795,8 @@ t_subscribe() ->
 t_simple_pool()->
     Key = p1w1,
     From = {n,l,Key},
-    P = t_spawn_reg(From),
-
+    _P = t_spawn_reg(From),
+    
     %% create a new pool
     ?assertEqual(gproc_pool:new(p1), ok),
 
@@ -818,7 +818,7 @@ t_simple_pool()->
     Ref = erlang:make_ref(),
     gproc:send(From, {self(), Ref, die}),
     receive
-        {_, Ref, Returned}=X ->
+        {_, Ref, Returned} ->
             ?assertEqual(Returned, ok)
     after 1000 ->
             %% the next 3 tests should fail if the worker is still alive


### PR DESCRIPTION
Fix some compiler warnings, and a bug which caused dist_test failure when adding a monitor from a non-leader node (a faulty return value in `gproc_dist:add_follow_to_waiters/5`).