### PR TITLE
replication of prop deletes buggy

### DIFF
--- a/src/gproc_dist.erl
+++ b/src/gproc_dist.erl
@@ -794,10 +794,8 @@ insert_globals(Globals) ->
 
 delete_globals(Globals) ->
     lists:foreach(
-      fun({{_,g,_},T} = K) when is_atom(T) ->
+      fun({{_,g,_},T} = K) when is_atom(T); is_pid(T) ->
               ets:delete(?TAB, K);
-         ({Key, Pid}) when is_pid(Pid); Pid==shared ->
-              ets:delete(?TAB, {Pid, Key});
          ({Pid, Key}) when is_pid(Pid); Pid==shared ->
 	      ets:delete(?TAB, {Pid, Key})
       end, Globals).

--- a/test/gproc_dist_tests.erl
+++ b/test/gproc_dist_tests.erl
@@ -67,6 +67,9 @@ dist_test_() ->
                                        ?debugVal(t_shared_counter(Ns))
                                end,
                                fun() ->
+                                       ?debugVal(t_prop(Ns))
+                               end,
+                               fun() ->
                                        ?debugVal(t_mreg(Ns))
                                end,
                                fun() ->
@@ -124,6 +127,7 @@ run_dist_tests() ->
 -define(T_NAME, {n, g, {?MODULE, ?LINE, erlang:now()}}).
 -define(T_KVL, [{foo, "foo"}, {bar, "bar"}]).
 -define(T_COUNTER, {c, g, {?MODULE, ?LINE}}).
+-define(T_PROP, {p, g, ?MODULE}).
 
 t_simple_reg([H|_] = Ns) ->
     Name = ?T_NAME,
@@ -222,6 +226,15 @@ t_update_counters([H1,H2|_] = Ns) ->
     ?assertMatch(ok, t_call(P12, die)),
     ?assertMatch(ok, t_call(P2, die)).
 
+t_prop([H1,H2|_] = Ns) ->
+    {p, g, _} = P = ?T_PROP,
+    P1 = t_spawn_reg(H1, P, 1),
+    P2 = t_spawn_reg(H2, P, 2),
+    ?assertMatch(ok, t_read_everywhere(P, P1, Ns, 1)),
+    ?assertMatch(ok, t_read_everywhere(P, P2, Ns, 2)),
+    ?assertMatch(ok, t_call(P1, die)),
+    ?assertMatch(ok, t_read_everywhere(P, P1, Ns, badarg)),
+    ?assertMatch(ok, t_call(P2, die)).
 
 t_mreg([H|_] = Ns) ->
     Kvl = ?T_KVL,


### PR DESCRIPTION
Addresses issues #87 #88 

There was no test case for global properties. Added one that checks replication of new properties as well as removal of property after process death.