### PR TITLE
Address issue where crashed process wasn't unregged on remote node

### DIFF
--- a/src/gproc_dist.erl
+++ b/src/gproc_dist.erl
@@ -836,6 +836,8 @@ delete_globals(Globals) ->
     lists:foreach(
       fun({{_,g,_},T} = K) when is_atom(T); is_pid(T) ->
               ets:delete(?TAB, K);
+	 ({{{_,g,_},T} = K, _}) when is_atom(T); is_pid(T) ->
+	      ets:delete(?TAB, K);
          ({Pid, Key}) when is_pid(Pid); Pid==shared ->
 	      ets:delete(?TAB, {Pid, Key})
       end, Globals).

--- a/src/gproc_dist.erl
+++ b/src/gproc_dist.erl
@@ -836,9 +836,10 @@ delete_globals(Globals) ->
     lists:foreach(
       fun({{_,g,_},T} = K) when is_atom(T); is_pid(T) ->
               ets:delete(?TAB, K);
-	 ({{{_,g,_},T} = K, P}) when is_pid(P),is_atom(T); is_pid(P),is_pid(T) ->
-	      ets:delete(?TAB, {P, K}),
-	      ets:delete(?TAB, K);
+         ({{{_,g,_} = R, T} = K, P}) when is_pid(P), is_atom(T);
+                                          is_pid(P), is_pid(T) ->
+              ets:delete(?TAB, {P, R}),
+              ets:delete(?TAB, K);
          ({Pid, Key}) when is_pid(Pid); Pid==shared ->
 	      ets:delete(?TAB, {Pid, Key})
       end, Globals).

--- a/src/gproc_dist.erl
+++ b/src/gproc_dist.erl
@@ -838,7 +838,7 @@ delete_globals(Globals) ->
               remove_entry(K, T, []);
          ({{{_,g,_} = K, T}, P}) when is_pid(P), is_atom(T);
                                           is_pid(P), is_pid(T) ->
-	      remove_entry(K, T, []);
+	      remove_entry(K, P, []);
          ({Pid, Key}) when is_pid(Pid); Pid==shared ->
 	      ets:delete(?TAB, {Pid, Key})
       end, Globals).

--- a/src/gproc_dist.erl
+++ b/src/gproc_dist.erl
@@ -836,7 +836,8 @@ delete_globals(Globals) ->
     lists:foreach(
       fun({{_,g,_},T} = K) when is_atom(T); is_pid(T) ->
               ets:delete(?TAB, K);
-	 ({{{_,g,_},T} = K, _}) when is_atom(T); is_pid(T) ->
+	 ({{{_,g,_},T} = K, P}) when is_pid(P),is_atom(T); is_pid(P),is_pid(T) ->
+	      ets:delete(?TAB, {P, K}),
 	      ets:delete(?TAB, K);
          ({Pid, Key}) when is_pid(Pid); Pid==shared ->
 	      ets:delete(?TAB, {Pid, Key})

--- a/src/gproc_dist.erl
+++ b/src/gproc_dist.erl
@@ -881,7 +881,7 @@ surrendered_1(Globs) ->
     My_local_globs =
         ets:select(?TAB, [{{{{'_',g,'_'},'_'},'$1', '$2'},
                            [{'==', {node,'$1'}, node()}],
-                           [{{ {element,1,{element,1,'$_'}}, '$1', '$2' }}]}]),
+                           [{{ {element,1,'$_'}, '$1', '$2' }}]}]),
     _ = [gproc_lib:ensure_monitor(Pid, g) || {_, Pid, _} <- My_local_globs],
     %% remove all remote globals.
     ets:select_delete(?TAB, [{{{{'_',g,'_'},'_'}, '$1', '_'},

--- a/src/gproc_trace.hrl
+++ b/src/gproc_trace.hrl
@@ -1,0 +1,5 @@
+-define(event(E), event(?LINE, E, [])).
+-define(event(E, S), event(?LINE, E, S)).
+
+event(_L, _E, _S) ->
+    ok.


### PR DESCRIPTION
This was superficially due to a failed pattern-match in delete_globals(),
but the real issue was that the distr messages for orderly unreg and
cleanup after exit were different. A first quick attempt at fixing
this didn't fix everything, so a slightly laxer test in remove_entry/3
made the test suite pass. However, this means that there is still a
discrepancy that *might* be unsafe, and at the very least is ugly.