### PR TITLE
fix distributed monitor(Key, standby) when the name is not yet registered

### DIFF
--- a/src/gproc_dist.erl
+++ b/src/gproc_dist.erl
@@ -1026,7 +1026,10 @@ pid_to_give_away_to({T,g,_} = Key) when T==n; T==a ->
 
 insert_reg([{_, Waiters}], K, Val, Pid, Event) ->
     gproc_lib:insert_reg(K, Val, Pid, g),
-    tell_waiters(Waiters, K, Pid, Val, Event).
+    tell_waiters(Waiters, K, Pid, Val, Event);
+insert_reg([], K, Val, Pid, Event) ->
+    gproc_lib:insert_reg(K, Val, Pid, g),
+    tell_waiters([], K, Val, Pid, Event).
 
 tell_waiters([{P,R}|T], K, Pid, V, Event) ->
     Msg = {gproc, R, registered, {K, Pid, V}},

--- a/test/gproc_dist_tests.erl
+++ b/test/gproc_dist_tests.erl
@@ -76,6 +76,7 @@ basic_tests(Ns) ->
      ?f(t_sync(Ns)),
      ?f(t_monitor(Ns)),
      ?f(t_standby_monitor(Ns)),
+     ?f(t_standby_monitor_unreg(Ns)),
      ?f(t_follow_monitor(Ns)),
      ?f(t_subscribe(Ns))
     ].
@@ -430,6 +431,16 @@ t_standby_monitor([A,B|_] = Ns) ->
     Ref1 = t_call(Pc, {apply, gproc, monitor, [Na, standby]}),
     ?assertMatch(true, t_call(Pb, {apply, gproc, unreg, [Na]})),
     ?assertMatch({gproc,unreg,Ref1,Na}, got_msg(Pc, gproc)),
+    ?assertMatch(ok, t_lookup_everywhere(Na, Ns, undefined)).
+
+t_standby_monitor_unreg([A,B|_] = Ns) ->
+    Na = ?T_NAME,
+    Pa = t_spawn(A, _Selective = true),
+    Ref = t_call(Pa, {apply, gproc, monitor, [Na, standby]}),
+    ?assert(is_reference(Ref)),
+    ?assertMatch({gproc,{failover,Pa},Ref,Na}, got_msg(Pa, gproc)),
+    ?assertMatch(ok, t_lookup_everywhere(Na, Ns, Pa)),
+    ?assertMatch(ok, t_call(Pa, die)),
     ?assertMatch(ok, t_lookup_everywhere(Na, Ns, undefined)).
 
 t_follow_monitor([A,B|_]) ->


### PR DESCRIPTION
Steps to reproduce the bug in original version:

INIT:

node1:
erl -sname n1 -pa ebin -pa deps/*/ebin

node2:
erl -sname n2 -pa ebin -pa deps/*/ebin

node1:
net_adm:ping('n2@carcharodon'), application:ensure_started(gproc), gproc_dist:start_link(all).

node2:
net_adm:ping('n1@carcharodon'), application:ensure_started(gproc), gproc_dist:start_link(all).

TEST:

node1:
gproc:monitor({n, g, test}, standby).                                                                                

=ERROR REPORT==== 7-May-2016::21:09:29 ===
*\* Generic leader gproc_dist terminating 
*\* Last message in was {'$leader_call',
                           {<0.45.0>,#Ref<0.0.2.214>},
                           {monitor,{n,g,test},<0.45.0>,standby}}
*\* When Server state == {state,false,true,[]}
*\* Reason for termination == 
*\* {function_clause,[{gproc_dist,insert_reg,
                                 [[],
                                  {n,g,test},
                                  undefined,<0.45.0>,
                                  {failover,<0.45.0>}],
                                 [{file,"src/gproc_dist.erl"},{line,1027}]},
                     {gproc_dist,handle_leader_call,4,
                                 [{file,"src/gproc_dist.erl"},{line,397}]},
                     {gen_leader,handle_msg,4,
                                 [{file,"src/gen_leader.erl"},{line,1103}]},
                     {proc_lib,init_p_do_apply,3,
                               [{file,"proc_lib.erl"},{line,240}]}]}
*\* exception exit: function_clause
     in function  gproc_dist:insert_reg/5
        called as gproc_dist:insert_reg([],{n,g,test},undefined,<0.45.0>,{failover,<0.45.0>})
     in call from gproc_dist:handle_leader_call/4 (src/gproc_dist.erl, line 397)
     in call from gen_leader:handle_msg/4 (src/gen_leader.erl, line 1103)
     in call from proc_lib:init_p_do_apply/3 (proc_lib.erl, line 240)

With fix applied:

INIT:
...
TEST:

node1:
gproc:monitor({n, g, test}, standby).    
# Ref<0.0.2.234>

flush().
Shell got {gproc,{failover,<0.45.0>},#Ref<0.0.2.234>,{n,g,test}}

node2:
gproc:where({n, g, test}).
<15262.45.0>
