### PR TITLE
ensure_reg() and ensure_reg_other()

### DIFF
--- a/test/gproc_dist_tests.erl
+++ b/test/gproc_dist_tests.erl
@@ -574,7 +574,8 @@ t_sleep() ->
     timer:sleep(500).
 
 t_lookup_everywhere(Key, Nodes, Exp) ->
-    t_lookup_everywhere(Key, Nodes, Exp, 10).
+    true = rpc:call(hd(Nodes), gproc_dist, sync, []),
+    t_lookup_everywhere(Key, Nodes, Exp, 3).
 
 t_lookup_everywhere(Key, _, Exp, 0) ->
     {lookup_failed, Key, Exp};
@@ -593,7 +594,8 @@ t_lookup_everywhere(Key, Nodes, Exp, I) ->
     end.
 
 t_read_everywhere(Key, Pid, Nodes, Exp) ->
-    t_read_everywhere(Key, Pid, Nodes, Exp, 10).
+    true = rpc:call(hd(Nodes), gproc_dist, sync, []),
+    t_read_everywhere(Key, Pid, Nodes, Exp, 3).
 
 t_read_everywhere(Key, _, _, Exp, 0) ->
     {read_failed, Key, Exp};

--- a/test/gproc_dist_tests.erl
+++ b/test/gproc_dist_tests.erl
@@ -574,7 +574,7 @@ t_sleep() ->
     timer:sleep(500).
 
 t_lookup_everywhere(Key, Nodes, Exp) ->
-    t_lookup_everywhere(Key, Nodes, Exp, 3).
+    t_lookup_everywhere(Key, Nodes, Exp, 10).
 
 t_lookup_everywhere(Key, _, Exp, 0) ->
     {lookup_failed, Key, Exp};
@@ -593,7 +593,7 @@ t_lookup_everywhere(Key, Nodes, Exp, I) ->
     end.
 
 t_read_everywhere(Key, Pid, Nodes, Exp) ->
-    t_read_everywhere(Key, Pid, Nodes, Exp, 3).
+    t_read_everywhere(Key, Pid, Nodes, Exp, 10).
 
 t_read_everywhere(Key, _, _, Exp, 0) ->
     {read_failed, Key, Exp};

--- a/test/gproc_dist_tests.erl
+++ b/test/gproc_dist_tests.erl
@@ -477,9 +477,11 @@ t_follow_monitor([A,B|_]) ->
     Na = ?T_NAME,
     Pa = t_spawn(A, _Selective = true),
     Ref = t_call(Pa, {apply, gproc, monitor, [Na, follow]}),
-    {gproc,unreg,Ref,Na} = got_msg(Pa),
+    Msg1 = {gproc,unreg,Ref,Na},
+    {Msg1, Msg1} = {got_msg(Pa), Msg1},
     Pb = t_spawn_reg(B, Na),
-    {gproc,registered,Ref,Na} = got_msg(Pa),
+    Msg2 = {gproc,registered,Ref,Na},
+    {Msg2, Msg2} = {got_msg(Pa), Msg2},
     ok = t_call(Pb, die),
     ok = t_call(Pa, die).
 


### PR DESCRIPTION
@spec ensure_reg(Key::key(), Value::value(), Attrs::attrs()) ->
          new | updated

@doc Registers a new name or property unless such and entry (by key) has
already been registered by the current process. If `Key` already exists,
the entry will be updated with the given `Value` and `Attrs`.

This function allows the caller to efficiently register an entry without
first checking whether it has already been registered. An exception is
raised if the name or property is already registered by someone else.
@end