### PR TITLE
gproc_ext, first commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@
 ## DEALINGS IN THE SOFTWARE.
 REBAR=$(shell which rebar || echo ./rebar)
 
-.PHONY: all compile clean eunit test eqc doc check dialyzer
+.PHONY: all compile clean eunit test eqc doc check dialyzer di
 
 DIRS=src
 
@@ -46,5 +46,7 @@ test: eunit
 doc:
 	$(REBAR) get-deps compile doc
 
-dialyzer:
+dialyzer: compile
 	$(REBAR) skip_deps=true dialyze
+
+di: dialyzer

--- a/rebar.config
+++ b/rebar.config
@@ -6,11 +6,13 @@
 	 {git, "https://github.com/garret-smith/gen_leader_revival.git", "HEAD"}}
        ]}.
 {dialyzer_opts, [{warnings, [no_unused,
+			     no_undefined_callbacks,
                              no_improper_lists, no_fun_app, no_match,
                              no_opaque, no_fail_call,
                              error_handling, no_match,
                              unmatched_returns,
-                             behaviours, underspecs]}]}.
+                             behaviours,
+			     underspecs]}]}.
 {edoc_opts, [{doclet, edown_doclet},
 	     {app_default, "http://www.erlang.org/doc/man"},
              {top_level_readme,

--- a/src/gproc_ext.erl
+++ b/src/gproc_ext.erl
@@ -1,0 +1,21 @@
+-module(gproc_ext).
+
+-export([reg_type/2]).
+
+
+reg_type(rw, _N) ->
+    #{tag => rw,
+      type => r,
+      unique => false,
+      scan   => [],
+      aggr   => [],
+      rc     => [#{tag => rwc}, #{tag => rwc, wild => [0]}]};
+reg_type(rcw, _N) ->
+    #{tag    => rcw,
+      type   => rc,
+      unique => true,
+      scan   => [#{tag => rc}],
+      aggr   => [],
+      rc     => []};
+reg_type(_, _) ->
+    undefined.

--- a/src/gproc_int.hrl
+++ b/src/gproc_int.hrl
@@ -29,3 +29,9 @@
 %% Used to wrap operations that may fail, but we ignore the exception.
 %% Use instead of catch, to avoid building a stacktrace unnecessarily.
 -define(MAY_FAIL(Expr), try (Expr) catch _:_ -> '$caught_exception' end).
+
+-ifdef(GPROC_EXT).
+-define(GPROC_EXT_CB, ?GPROC_EXT).
+-else.
+-define(GPROC_EXT_CB, gproc_ext).
+-endif.

--- a/test/gproc_dist_tests.erl
+++ b/test/gproc_dist_tests.erl
@@ -474,7 +474,7 @@ t_standby_monitor([A,B|_] = Ns) ->
     ?assertMatch({gproc,unreg,Ref1,Na}, got_msg(Pc, gproc)),
     ?assertMatch(ok, t_lookup_everywhere(Na, Ns, undefined)).
 
-t_standby_monitor_unreg([A,B|_] = Ns) ->
+t_standby_monitor_unreg([A|_] = Ns) ->
     Na = ?T_NAME,
     Pa = t_spawn(A, _Selective = true),
     Ref = t_call(Pa, {apply, gproc, monitor, [Na, standby]}),

--- a/test/gproc_tests.erl
+++ b/test/gproc_tests.erl
@@ -22,7 +22,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("stdlib/include/qlc.hrl").
 
--define(T_NAME, {n, l, {?MODULE, ?LINE, erlang:now()}}).
+-define(T_NAME, {n, l, {?MODULE, ?LINE, os:timestamp()}}).
 
 conf_test_() ->
     {foreach,


### PR DESCRIPTION
Still work in progress, but test suite passes.

Introduce a metadata map and a configurable callback module (default: `gproc_ext`), which can define additional gproc registry types. The custom types must be variants of the default types (`p`, `n`, `c`, `a`, `r`, `rc`). The `gproc_ext.erl` module adds the types `rw` and `rcw` (resource counters with wildcard support).

TODO: benchmark different operations to check whether the changes incur noticable overhead.