### PR TITLE
Exclude nodes as cluster leaders

### DIFF
--- a/src/gproc_dist.erl
+++ b/src/gproc_dist.erl
@@ -79,7 +79,13 @@ start_link() ->
     start_link({[node()|nodes()], []}).
 
 start_link(all) ->
-    start_link({[node()|nodes()], [{bcast_type, all}]});
+    Workers = case application:get_env(gproc_dist_workers) of
+               undefined -> [];
+               {ok, false} -> [];
+               {ok, WorkersList} when is_list(WorkersList) -> WorkersList;
+               {ok, _} -> []
+    end,
+    start_link({[node()|nodes()], [{bcast_type, all}, {workers, Workers}]});
 start_link(Nodes) when is_list(Nodes) ->
     start_link({Nodes, []});
 start_link({Nodes, Opts}) ->

--- a/src/gproc_dist.erl
+++ b/src/gproc_dist.erl
@@ -80,10 +80,8 @@ start_link() ->
 
 start_link(all) ->
     Workers = case application:get_env(gproc_dist_workers) of
-               undefined -> [];
-               {ok, false} -> [];
-               {ok, WorkersList} when is_list(WorkersList) -> WorkersList;
-               {ok, _} -> []
+        {ok, [_|_] = WorkersList} -> WorkersList;
+        _ -> []
     end,
     start_link({[node()|nodes()], [{bcast_type, all}, {workers, Workers}]});
 start_link(Nodes) when is_list(Nodes) ->


### PR DESCRIPTION
In my application I have a star topology. So I would like to exclude workers connecting to the central node from becoming cluster leaders as I occasionally observe gproc errors when they elect themselves as leaders.

I hope this pull request is up to standards. First try...