### PR TITLE
Remove deprecation warning since r18

### DIFF
--- a/test/gproc_tests.erl
+++ b/test/gproc_tests.erl
@@ -22,7 +22,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("stdlib/include/qlc.hrl").
 
--define(T_NAME, {n, l, {?MODULE, ?LINE, erlang:now()}}).
+-define(T_NAME, {n, l, {?MODULE, ?LINE, erlang:timestamp()}}).
 
 conf_test_() ->
     {foreach,


### PR DESCRIPTION
Use erlang:timestamp/1 instead of (deprecated since r18) erlang:now/1. I don't think it could cause an incompatibility issue since the oldest Travis-CI Erlang version used is R18 anyway.

Signed-off-by: Peter Lemenkov <lemenkov@gmail.com>