### PR TITLE
Uw rewrite sync

### DIFF
--- a/test/gproc_dist_tests.erl
+++ b/test/gproc_dist_tests.erl
@@ -25,7 +25,7 @@
 -define(f(E), fun() -> ?debugVal(E) end).
 
 dist_test_() ->
-    {timeout, 180,
+    {timeout, 120,
      [
       %% {setup,
       %%  fun dist_setup/0,
@@ -49,7 +49,7 @@ dist_test_() ->
                 tests(Ns, [?f(t_fail_node(Ns))])
         end,
         fun(Ns) ->
-                tests(Ns, [{timeout, 15, ?f(t_master_dies(Ns))}])
+                tests(Ns, [{timeout, 10, ?f(t_master_dies(Ns))}])
         end
        ]}
      ]}.
@@ -575,6 +575,7 @@ t_sync_cand_dies([A,B,C]) ->
     %% immediately. Therefore, we should have our answer well within 1 sec.
     ?assertMatch({value, true}, rpc:nb_yield(Key, 1000)).
 
+
 %% Verify that the registry updates consistently if a non-leader node
 %% dies.
 t_fail_node(Ns) ->
@@ -628,7 +629,7 @@ try_sync(N, Ns) ->
                "  ~p~n"
                "Status = ~p~n",
                [Err, N,
-                {Ns, rpc:multicall(Ns, sys, get_status, [gproc_dist])}]),
+                {Ns, rpc:multicall([N|Ns], sys, get_status, [gproc_dist])}]),
             Err;
         true ->
             true


### PR DESCRIPTION
    Rewrite gproc_dist:sync() to hopefully be more robust
    
    The old version used gen_leader:leader_call(), which doesn't do well
    if the leader dies, or similar things happen. The new solution calls
    the local gproc_dist, which remembers the request and casts to the
    leader (assuming it's not itself the leader). The leader performs
    the sync as before, then casts to the intitial node that the sync
    is complete. If a new leader is elected, the other nodes check
    pending sync requests and re-initiate them.
    
    Timeouts, which were recently increased, returned to their previous
    values.
