### PR TITLE
Catch error from gproc:reset_counter/1

### DIFF
--- a/src/gproc_pool.erl
+++ b/src/gproc_pool.erl
@@ -91,6 +91,8 @@
          test_run0/2, setup_test_pool/3, setup_test_pool/4,
 	 remove_test_pool/1]).
 
+-include("gproc_int.hrl").
+
 -define(POOL(Pool), {p,l,{?MODULE,Pool}}).
 -define(POOL_CUR(Pool), {c,l,{?MODULE,Pool,cur}}).
 -define(POOL_WRK(Pool,Name), {c,l,{?MODULE,Pool,w,Name}}).
@@ -551,7 +553,8 @@ execute_claim(F, K, Pid) ->
         end
     after
         exit(Mon, kill),
-        gproc:reset_counter(K)
+        %% Can crash when Pid dies and dissociates from K.
+        ?MAY_FAIL(gproc:reset_counter(K))
     end.
 
 setup_wait(nowait, _) ->


### PR DESCRIPTION
in gproc_pool:execute_claim/3. During the course of execute_claim/3 if
Pid dies gproc:reset_counter/1 may crash

** exception error: no match of right hand side value []
     in function  gproc:reset_counter1/1 (gproc.erl, line 1895)
     in call from gproc:reset_counter/1 (gproc.erl, line 1889)
     in call from gproc_pool:execute_claim/3 (gproc_pool.erl, line 548)
     in call from gproc_pool:try_claim/2 (gproc_pool.erl, line 501)
     in call from gproc_pool:claim_/2 (gproc_pool.erl, line 473)
     in call from gproc_pool:claim_w/3 (gproc_pool.erl, line 452)
....

which completely obscures the real crash. With this change you instead
get:

** exception exit: {{shutdown,timeout},
                    {gen_statem,call,
                                [<0.14440.1>,
                                 {query,[<<81,0,0,0,25>>,["SELECT pg_sleep(60);",0]],5000},
                                 infinity]}}
     in function  gen:do_call/4 (gen.erl, line 177)
     in call from gen_statem:call_dirty/4 (gen_statem.erl, line 598)
     in call from gproc_pool:execute_claim/3 (gproc_pool.erl, line 549)
....