### PR TITLE
Only shrink the pool when auto_size is true

### DIFF
--- a/test/gproc_tests.erl
+++ b/test/gproc_tests.erl
@@ -162,7 +162,9 @@ reg_test_() ->
       , ?_test(t_is_clean())
       , {spawn, ?_test(?debugVal(t_simple_pool()))}
       , ?_test(t_is_clean())
-      , {spawn, ?_test(?debugVal(t_pool_add_worker_race()))}
+      , {spawn, ?_test(?debugVal(t_pool_add_worker_size_1_no_auto_size()))}
+      , ?_test(t_is_clean())
+      , {spawn, ?_test(?debugVal(t_pool_add_worker_size_2_no_auto_size()))}
       , ?_test(t_is_clean())
      ]}.
 
@@ -1007,25 +1009,26 @@ t_simple_pool()->
 
 %% verifying #167 - Removing a worker from a pool does not make room
 %% for a new worker (size was erroneously adjusted down, though auto_size = false)
-t_pool_add_worker_race() ->
+t_pool_add_worker_size_1_no_auto_size() ->
     ok = gproc_pool:new(p2, direct, [{size, 1}, {auto_size, false}]),
     [] = gproc_pool:defined_workers(p2),
     Pos1 = gproc_pool:add_worker(p2, worker1),
     [{worker1, Pos1, 0}] = gproc_pool:defined_workers(p2),
     io:fwrite("G = ~p~n", [ets:tab2list(gproc)]),
-    Pid = spawn(fun() ->
-                        true = gproc_pool:connect_worker(p2, worker1),
-                        receive after 100 -> bye end
-                end),
-    Monitor = monitor(process, Pid),
-    receive
-        {'DOWN', Monitor, process, _, _} -> ok
-    end,
     true = gproc_pool:remove_worker(p2, worker1),
     [] = gproc_pool:defined_workers(p2), %% the pool seems to be empty
     Pos2 = gproc_pool:add_worker(p2, worker2), %% throws error:pool_full
     true = is_integer(Pos2),
     true = gproc_pool:force_delete(p2).
+
+t_pool_add_worker_size_2_no_auto_size() ->
+    gproc_pool:new(p3, direct, [{size, 2}, {auto_size, false}]),
+    gproc_pool:add_worker(p3, worker1),
+    gproc_pool:add_worker(p3, worker2),
+    gproc_pool:remove_worker(p3, worker2),
+    gproc_pool:add_worker(p3, worker3),
+    gproc_pool:force_delete(p3).
+
 
 
 


### PR DESCRIPTION
The previous fix for issue #167 only seems to work for pools of size 1. `del_slot/2` still removed a worker slot if its name was located at the end of the list of workers.

With this change, the worker pool is not lopped off when `auto_size =:= false`.

Also included a unit test that provokes this bug.
