### PR TITLE
Remote reg and pub/sub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ eunit:
 test: eunit
 
 doc:
-	$(REBAR3) doc
+	$(REBAR3) as edown edoc
 
 dialyzer:
-	$(REBAR3) dialyzer
+	GPROC_DIST=true $(REBAR3) dialyzer

--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ alternative sources, and cache them for efficient lookup. Caching also provides
 a way to see which processes rely on certain configuration values, as well as
 which values they actually ended up using.
 
-See [`gproc:get_env/4`](http://github.com/uwiger/gproc/blob/uw-change-license/doc/gproc.md#get_env-4), [`gproc:get_set_env/4`](http://github.com/uwiger/gproc/blob/uw-change-license/doc/gproc.md#get_set_env-4) and
-[`gproc:set_env/5`](http://github.com/uwiger/gproc/blob/uw-change-license/doc/gproc.md#set_env-5) for details.
+See [`gproc:get_env/4`](http://github.com/uwiger/gproc/blob/master/doc/gproc.md#get_env-4), [`gproc:get_set_env/4`](http://github.com/uwiger/gproc/blob/master/doc/gproc.md#get_set_env-4) and
+[`gproc:set_env/5`](http://github.com/uwiger/gproc/blob/master/doc/gproc.md#set_env-5) for details.
 
 
 ## Testing ##
@@ -108,22 +108,23 @@ By default, `./rebar doc` generates Github-flavored Markdown files.
 If you want to change this, remove the `edoc_opts` line from `rebar.config`.
 
 Gproc was first introduced at the ACM SIGPLAN Erlang Workshop in
-Freiburg 2007 ([Paper available here](http://github.com/uwiger/gproc/blob/uw-change-license/doc/erlang07-wiger.pdf)).
+Freiburg 2007 ([Paper available here](http://github.com/uwiger/gproc/blob/master/doc/erlang07-wiger.pdf)).
 
 
 ## Modules ##
 
 
 <table width="100%" border="0" summary="list of modules">
-<tr><td><a href="http://github.com/uwiger/gproc/blob/uw-change-license/doc/gproc.md" class="module">gproc</a></td></tr>
-<tr><td><a href="http://github.com/uwiger/gproc/blob/uw-change-license/doc/gproc_app.md" class="module">gproc_app</a></td></tr>
-<tr><td><a href="http://github.com/uwiger/gproc/blob/uw-change-license/doc/gproc_bcast.md" class="module">gproc_bcast</a></td></tr>
-<tr><td><a href="http://github.com/uwiger/gproc/blob/uw-change-license/doc/gproc_dist.md" class="module">gproc_dist</a></td></tr>
-<tr><td><a href="http://github.com/uwiger/gproc/blob/uw-change-license/doc/gproc_info.md" class="module">gproc_info</a></td></tr>
-<tr><td><a href="http://github.com/uwiger/gproc/blob/uw-change-license/doc/gproc_init.md" class="module">gproc_init</a></td></tr>
-<tr><td><a href="http://github.com/uwiger/gproc/blob/uw-change-license/doc/gproc_lib.md" class="module">gproc_lib</a></td></tr>
-<tr><td><a href="http://github.com/uwiger/gproc/blob/uw-change-license/doc/gproc_monitor.md" class="module">gproc_monitor</a></td></tr>
-<tr><td><a href="http://github.com/uwiger/gproc/blob/uw-change-license/doc/gproc_pool.md" class="module">gproc_pool</a></td></tr>
-<tr><td><a href="http://github.com/uwiger/gproc/blob/uw-change-license/doc/gproc_ps.md" class="module">gproc_ps</a></td></tr>
-<tr><td><a href="http://github.com/uwiger/gproc/blob/uw-change-license/doc/gproc_pt.md" class="module">gproc_pt</a></td></tr>
-<tr><td><a href="http://github.com/uwiger/gproc/blob/uw-change-license/doc/gproc_sup.md" class="module">gproc_sup</a></td></tr></table>
+<tr><td><a href="http://github.com/uwiger/gproc/blob/master/doc/gproc.md" class="module">gproc</a></td></tr>
+<tr><td><a href="http://github.com/uwiger/gproc/blob/master/doc/gproc_app.md" class="module">gproc_app</a></td></tr>
+<tr><td><a href="http://github.com/uwiger/gproc/blob/master/doc/gproc_bcast.md" class="module">gproc_bcast</a></td></tr>
+<tr><td><a href="http://github.com/uwiger/gproc/blob/master/doc/gproc_dist.md" class="module">gproc_dist</a></td></tr>
+<tr><td><a href="http://github.com/uwiger/gproc/blob/master/doc/gproc_info.md" class="module">gproc_info</a></td></tr>
+<tr><td><a href="http://github.com/uwiger/gproc/blob/master/doc/gproc_init.md" class="module">gproc_init</a></td></tr>
+<tr><td><a href="http://github.com/uwiger/gproc/blob/master/doc/gproc_lib.md" class="module">gproc_lib</a></td></tr>
+<tr><td><a href="http://github.com/uwiger/gproc/blob/master/doc/gproc_monitor.md" class="module">gproc_monitor</a></td></tr>
+<tr><td><a href="http://github.com/uwiger/gproc/blob/master/doc/gproc_pool.md" class="module">gproc_pool</a></td></tr>
+<tr><td><a href="http://github.com/uwiger/gproc/blob/master/doc/gproc_ps.md" class="module">gproc_ps</a></td></tr>
+<tr><td><a href="http://github.com/uwiger/gproc/blob/master/doc/gproc_pt.md" class="module">gproc_pt</a></td></tr>
+<tr><td><a href="http://github.com/uwiger/gproc/blob/master/doc/gproc_sup.md" class="module">gproc_sup</a></td></tr></table>
+

--- a/doc/README.md
+++ b/doc/README.md
@@ -6,7 +6,7 @@ __Authors:__ Ulf Wiger ([`ulf@wiger.net`](mailto:ulf@wiger.net)), Joseph Wayne N
 
 Extended process dictionary
 
-[![Build Status](https://travis-ci.org/uwiger/gproc.png?branch=master)](https://travis-ci.org/uwiger/gproc)
+[![Build Status](https://github.com/uwiger/gproc/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/uwiger/gproc/actions/workflows/ci.yml)
 [![Hex pm](http://img.shields.io/hexpm/v/gproc.svg?style=flat)](https://hex.pm/packages/gproc)
 
 

--- a/doc/gproc.md
+++ b/doc/gproc.md
@@ -47,6 +47,26 @@ will improve performance.
 
 
 
+### <a name="type-attr">attr()</a> ###
+
+
+<pre><code>
+attr() = {atom(), any()}
+</code></pre>
+
+
+
+
+### <a name="type-attrs">attrs()</a> ###
+
+
+<pre><code>
+attrs() = [<a href="#type-attr">attr()</a>]
+</code></pre>
+
+
+
+
 ### <a name="type-context">context()</a> ###
 
 
@@ -221,7 +241,7 @@ sel_type() = <a href="#type-type">type()</a> | names | props | counters | aggr_c
 
 
 <pre><code>
-sel_var() = '_' | atom()
+sel_var() = _ | atom()
 </code></pre>
 
 
@@ -263,10 +283,10 @@ value() = any()
 This function is the reverse of monitor/1.</td></tr><tr><td valign="top"><a href="#ensure_reg-1">ensure_reg/1</a></td><td>Equivalent to <a href="#ensure_reg-3"><tt>ensure_reg(Key, default(Key), [])</tt></a>.</td></tr><tr><td valign="top"><a href="#ensure_reg-2">ensure_reg/2</a></td><td>Equivalent to <a href="#ensure_reg-3"><tt>ensure_reg(Key, Value, [])</tt></a>.</td></tr><tr><td valign="top"><a href="#ensure_reg-3">ensure_reg/3</a></td><td>Registers a new name or property unless such and entry (by key) has
 already been registered by the current process.</td></tr><tr><td valign="top"><a href="#ensure_reg_other-2">ensure_reg_other/2</a></td><td></td></tr><tr><td valign="top"><a href="#ensure_reg_other-3">ensure_reg_other/3</a></td><td>Equivalent to <a href="#ensure_reg_other-4"><tt>ensure_reg_other(Key, Pid, Value, [])</tt></a>.</td></tr><tr><td valign="top"><a href="#ensure_reg_other-4">ensure_reg_other/4</a></td><td>Register or update name or property to another process.</td></tr><tr><td valign="top"><a href="#first-1">first/1</a></td><td>Behaves as ets:first(Tab) for a given type of registration.</td></tr><tr><td valign="top"><a href="#get_attribute-2">get_attribute/2</a></td><td>Get attribute value of <code>Attr</code> associated with <code>Key</code> for most likely Pid.</td></tr><tr><td valign="top"><a href="#get_attribute-3">get_attribute/3</a></td><td>Get the attribute value of <code>Attr</code> associated with <code>Key</code> for process Pid.</td></tr><tr><td valign="top"><a href="#get_attribute_shared-2">get_attribute_shared/2</a></td><td>Get the attribute value of <code>Attr</code> associated with the shared <code>Key</code>.</td></tr><tr><td valign="top"><a href="#get_attributes-1">get_attributes/1</a></td><td>Get attributes associated with registration.</td></tr><tr><td valign="top"><a href="#get_attributes-2">get_attributes/2</a></td><td>Returns the list of attributes associated with the registration.</td></tr><tr><td valign="top"><a href="#get_env-3">get_env/3</a></td><td>Equivalent to <a href="#get_env-4"><tt>get_env(Scope, App, Key, [app_env])</tt></a>.</td></tr><tr><td valign="top"><a href="#get_env-4">get_env/4</a></td><td>Read an environment value, potentially cached as a <code>gproc_env</code> property.</td></tr><tr><td valign="top"><a href="#get_set_env-3">get_set_env/3</a></td><td>Equivalent to <a href="#get_set_env-4"><tt>get_set_env(Scope, App, Key, [app_env])</tt></a>.</td></tr><tr><td valign="top"><a href="#get_set_env-4">get_set_env/4</a></td><td>Fetch and cache an environment value, if not already cached.</td></tr><tr><td valign="top"><a href="#get_value-1">get_value/1</a></td><td>Reads the value stored with a key registered to the current process.</td></tr><tr><td valign="top"><a href="#get_value-2">get_value/2</a></td><td>Reads the value stored with a key registered to the process Pid.</td></tr><tr><td valign="top"><a href="#get_value_shared-1">get_value_shared/1</a></td><td>Reads the value stored with a shared key.</td></tr><tr><td valign="top"><a href="#give_away-2">give_away/2</a></td><td>Atomically transfers the key <code>From</code> to the process identified by <code>To</code>.</td></tr><tr><td valign="top"><a href="#goodbye-0">goodbye/0</a></td><td>Unregister all items of the calling process and inform gproc
 to forget about the calling process.</td></tr><tr><td valign="top"><a href="#i-0">i/0</a></td><td>Similar to the built-in shell command <code>i()</code> but inserts information
-about names and properties registered in Gproc, where applicable.</td></tr><tr><td valign="top"><a href="#info-1">info/1</a></td><td>Similar to <code>process_info(Pid)</code> but with additional gproc info.</td></tr><tr><td valign="top"><a href="#info-2">info/2</a></td><td>Similar to process_info(Pid, Item), but with additional gproc info.</td></tr><tr><td valign="top"><a href="#last-1">last/1</a></td><td>Behaves as ets:last(Tab) for a given type of registration.</td></tr><tr><td valign="top"><a href="#lookup_global_aggr_counter-1">lookup_global_aggr_counter/1</a></td><td>Lookup a global (unique) aggregated counter and returns its value.</td></tr><tr><td valign="top"><a href="#lookup_global_counters-1">lookup_global_counters/1</a></td><td>Look up all global (non-unique) instances of a given Counter.</td></tr><tr><td valign="top"><a href="#lookup_global_name-1">lookup_global_name/1</a></td><td>Lookup a global unique name.</td></tr><tr><td valign="top"><a href="#lookup_global_properties-1">lookup_global_properties/1</a></td><td>Look up all global (non-unique) instances of a given Property.</td></tr><tr><td valign="top"><a href="#lookup_local_aggr_counter-1">lookup_local_aggr_counter/1</a></td><td>Lookup a local (unique) aggregated counter and returns its value.</td></tr><tr><td valign="top"><a href="#lookup_local_counters-1">lookup_local_counters/1</a></td><td>Look up all local (non-unique) instances of a given Counter.</td></tr><tr><td valign="top"><a href="#lookup_local_name-1">lookup_local_name/1</a></td><td>Lookup a local unique name.</td></tr><tr><td valign="top"><a href="#lookup_local_properties-1">lookup_local_properties/1</a></td><td>Look up all local (non-unique) instances of a given Property.</td></tr><tr><td valign="top"><a href="#lookup_pid-1">lookup_pid/1</a></td><td>Lookup the Pid stored with a key.</td></tr><tr><td valign="top"><a href="#lookup_pids-1">lookup_pids/1</a></td><td>Returns a list of pids with the published key Key.</td></tr><tr><td valign="top"><a href="#lookup_value-1">lookup_value/1</a></td><td>Lookup the value stored with a key.</td></tr><tr><td valign="top"><a href="#lookup_values-1">lookup_values/1</a></td><td>Retrieve the <code>{Pid,Value}</code> pairs corresponding to Key.</td></tr><tr><td valign="top"><a href="#monitor-1">monitor/1</a></td><td>Equivalent to <a href="#monitor-2"><tt>monitor(Key, info)</tt></a>.</td></tr><tr><td valign="top"><a href="#monitor-2">monitor/2</a></td><td>monitor a registered name
+about names and properties registered in Gproc, where applicable.</td></tr><tr><td valign="top"><a href="#info-1">info/1</a></td><td>Similar to <code>process_info(Pid)</code> but with additional gproc info.</td></tr><tr><td valign="top"><a href="#info-2">info/2</a></td><td>Similar to process_info(Pid, Item), but with additional gproc info.</td></tr><tr><td valign="top"><a href="#last-1">last/1</a></td><td>Behaves as ets:last(Tab) for a given type of registration.</td></tr><tr><td valign="top"><a href="#lookup_global_aggr_counter-1">lookup_global_aggr_counter/1</a></td><td>Lookup a global (unique) aggregated counter and returns its value.</td></tr><tr><td valign="top"><a href="#lookup_global_counters-1">lookup_global_counters/1</a></td><td>Look up all global (non-unique) instances of a given Counter.</td></tr><tr><td valign="top"><a href="#lookup_global_name-1">lookup_global_name/1</a></td><td>Lookup a global unique name.</td></tr><tr><td valign="top"><a href="#lookup_global_properties-1">lookup_global_properties/1</a></td><td>Look up all global (non-unique) instances of a given Property.</td></tr><tr><td valign="top"><a href="#lookup_global_resources-1">lookup_global_resources/1</a></td><td>Look up all global (non-unique) instances of a given Resource.</td></tr><tr><td valign="top"><a href="#lookup_local_aggr_counter-1">lookup_local_aggr_counter/1</a></td><td>Lookup a local (unique) aggregated counter and returns its value.</td></tr><tr><td valign="top"><a href="#lookup_local_counters-1">lookup_local_counters/1</a></td><td>Look up all local (non-unique) instances of a given Counter.</td></tr><tr><td valign="top"><a href="#lookup_local_name-1">lookup_local_name/1</a></td><td>Lookup a local unique name.</td></tr><tr><td valign="top"><a href="#lookup_local_properties-1">lookup_local_properties/1</a></td><td>Look up all local (non-unique) instances of a given Property.</td></tr><tr><td valign="top"><a href="#lookup_local_resources-1">lookup_local_resources/1</a></td><td>Look up all local (non-unique) instances of a given Resource.</td></tr><tr><td valign="top"><a href="#lookup_pid-1">lookup_pid/1</a></td><td>Lookup the Pid stored with a key.</td></tr><tr><td valign="top"><a href="#lookup_pids-1">lookup_pids/1</a></td><td>Returns a list of pids with the published key Key.</td></tr><tr><td valign="top"><a href="#lookup_value-1">lookup_value/1</a></td><td>Lookup the value stored with a key.</td></tr><tr><td valign="top"><a href="#lookup_values-1">lookup_values/1</a></td><td>Retrieve the <code>{Pid,Value}</code> pairs corresponding to Key.</td></tr><tr><td valign="top"><a href="#monitor-1">monitor/1</a></td><td>Equivalent to <a href="#monitor-2"><tt>monitor(Key, info)</tt></a>.</td></tr><tr><td valign="top"><a href="#monitor-2">monitor/2</a></td><td>monitor a registered name
 <code>monitor(Key, info)</code> works much like erlang:monitor(process, Pid), but monitors
 a unique name registered via gproc.</td></tr><tr><td valign="top"><a href="#mreg-3">mreg/3</a></td><td>Register multiple {Key,Value} pairs of a given type and scope.</td></tr><tr><td valign="top"><a href="#munreg-3">munreg/3</a></td><td>Unregister multiple Key items of a given type and scope.</td></tr><tr><td valign="top"><a href="#nb_wait-1">nb_wait/1</a></td><td>Wait for a name or aggregated counter to be registered.</td></tr><tr><td valign="top"><a href="#nb_wait-2">nb_wait/2</a></td><td>Wait for a name or aggregated counter to be registered on <code>Node</code>.</td></tr><tr><td valign="top"><a href="#next-2">next/2</a></td><td>Behaves as ets:next(Tab,Key) for a given type of registration.</td></tr><tr><td valign="top"><a href="#prev-2">prev/2</a></td><td>Behaves as ets:prev(Tab,Key) for a given type of registration.</td></tr><tr><td valign="top"><a href="#reg-1">reg/1</a></td><td>Equivalent to <a href="#reg-3"><tt>reg(Key, default(Key), [])</tt></a>.</td></tr><tr><td valign="top"><a href="#reg-2">reg/2</a></td><td>Register a name or property for the current process.</td></tr><tr><td valign="top"><a href="#reg-3">reg/3</a></td><td>Register a name or property for the current process
-<code>Attrs</code> (default: <code>[]</code>) can be inspected using <a href="#get_attribute-2"><code>get_attribute/2</code></a>.</td></tr><tr><td valign="top"><a href="#reg_or_locate-1">reg_or_locate/1</a></td><td>Equivalent to <a href="#reg_or_locate-2"><tt>reg_or_locate(Key, default(Key))</tt></a>.</td></tr><tr><td valign="top"><a href="#reg_or_locate-2">reg_or_locate/2</a></td><td>Try registering a unique name, or return existing registration.</td></tr><tr><td valign="top"><a href="#reg_or_locate-3">reg_or_locate/3</a></td><td>Spawn a process with a registered name, or return existing registration.</td></tr><tr><td valign="top"><a href="#reg_other-2">reg_other/2</a></td><td>Equivalent to <a href="#reg_other-4"><tt>reg_other(Key, Pid, default(Key), [])</tt></a>.</td></tr><tr><td valign="top"><a href="#reg_other-3">reg_other/3</a></td><td>Equivalent to <a href="#reg_other-4"><tt>reg_other(Key, Pid, Value, [])</tt></a>.</td></tr><tr><td valign="top"><a href="#reg_other-4">reg_other/4</a></td><td>Register name or property to another process.</td></tr><tr><td valign="top"><a href="#reg_shared-1">reg_shared/1</a></td><td>Register a resource, but don't tie it to a particular process.</td></tr><tr><td valign="top"><a href="#reg_shared-2">reg_shared/2</a></td><td>Register a resource, but don't tie it to a particular process.</td></tr><tr><td valign="top"><a href="#reg_shared-3">reg_shared/3</a></td><td></td></tr><tr><td valign="top"><a href="#register_name-2">register_name/2</a></td><td>Behaviour support callback.</td></tr><tr><td valign="top"><a href="#reset_counter-1">reset_counter/1</a></td><td>Reads and resets a counter in a "thread-safe" way.</td></tr><tr><td valign="top"><a href="#select-1">select/1</a></td><td>Perform a select operation on the process registry.</td></tr><tr><td valign="top"><a href="#select-2">select/2</a></td><td>Perform a select operation with limited context on the process registry.</td></tr><tr><td valign="top"><a href="#select-3">select/3</a></td><td>Like <a href="#select-2"><code>select/2</code></a> but returns Limit objects at a time.</td></tr><tr><td valign="top"><a href="#select_count-1">select_count/1</a></td><td>Equivalent to <a href="#select_count-2"><tt>select_count(all, Pat)</tt></a>.</td></tr><tr><td valign="top"><a href="#select_count-2">select_count/2</a></td><td>Perform a select_count operation on the process registry.</td></tr><tr><td valign="top"><a href="#send-2">send/2</a></td><td>Sends a message to the process, or processes, corresponding to Key.</td></tr><tr><td valign="top"><a href="#set_attributes-2">set_attributes/2</a></td><td>Add/modify <code>{Key, Value}</code> attributes associated with a registration.</td></tr><tr><td valign="top"><a href="#set_attributes_shared-2">set_attributes_shared/2</a></td><td>Add/modify <code>{Key, Value}</code> attributes associated with a shared registration.</td></tr><tr><td valign="top"><a href="#set_env-5">set_env/5</a></td><td>Updates the cached value as well as underlying environment.</td></tr><tr><td valign="top"><a href="#set_value-2">set_value/2</a></td><td>Sets the value of the registration given by Key.</td></tr><tr><td valign="top"><a href="#set_value_shared-2">set_value_shared/2</a></td><td>Sets the value of the shared registration given by Key.</td></tr><tr><td valign="top"><a href="#start_link-0">start_link/0</a></td><td>Starts the gproc server.</td></tr><tr><td valign="top"><a href="#table-0">table/0</a></td><td>Equivalent to <a href="#table-1"><tt>table({all, all})</tt></a>.</td></tr><tr><td valign="top"><a href="#table-1">table/1</a></td><td>Equivalent to <a href="#table-2"><tt>table(Context, [])</tt></a>.</td></tr><tr><td valign="top"><a href="#table-2">table/2</a></td><td>QLC table generator for the gproc registry.</td></tr><tr><td valign="top"><a href="#unreg-1">unreg/1</a></td><td>Unregister a name or property.</td></tr><tr><td valign="top"><a href="#unreg_other-2">unreg_other/2</a></td><td>Unregister a name registered to another process.</td></tr><tr><td valign="top"><a href="#unreg_shared-1">unreg_shared/1</a></td><td>Unregister a shared resource.</td></tr><tr><td valign="top"><a href="#unregister_name-1">unregister_name/1</a></td><td>Equivalent to <tt>unreg / 1</tt>.</td></tr><tr><td valign="top"><a href="#update_counter-2">update_counter/2</a></td><td>Updates the counter registered as Key for the current process.</td></tr><tr><td valign="top"><a href="#update_counter-3">update_counter/3</a></td><td></td></tr><tr><td valign="top"><a href="#update_counters-2">update_counters/2</a></td><td>Update a list of counters.</td></tr><tr><td valign="top"><a href="#update_shared_counter-2">update_shared_counter/2</a></td><td>Updates the shared counter registered as Key.</td></tr><tr><td valign="top"><a href="#where-1">where/1</a></td><td>Returns the pid registered as Key.</td></tr><tr><td valign="top"><a href="#whereis_name-1">whereis_name/1</a></td><td>Equivalent to <tt>where / 1</tt>.</td></tr><tr><td valign="top"><a href="#wide_await-3">wide_await/3</a></td><td>Wait for a local name to be registered on any of <code>Nodes</code>.</td></tr></table>
+<code>Attrs</code> (default: <code>[]</code>) can be inspected using <a docgen-rel="seemfa" docgen-href="#get_attribute/2" href="#get_attribute-2"><code>get_attribute/2</code></a>.</td></tr><tr><td valign="top"><a href="#reg_or_locate-1">reg_or_locate/1</a></td><td>Equivalent to <a href="#reg_or_locate-2"><tt>reg_or_locate(Key, default(Key))</tt></a>.</td></tr><tr><td valign="top"><a href="#reg_or_locate-2">reg_or_locate/2</a></td><td>Try registering a unique name, or return existing registration.</td></tr><tr><td valign="top"><a href="#reg_or_locate-3">reg_or_locate/3</a></td><td>Spawn a process with a registered name, or return existing registration.</td></tr><tr><td valign="top"><a href="#reg_other-2">reg_other/2</a></td><td>Equivalent to <a href="#reg_other-4"><tt>reg_other(Key, Pid, default(Key), [])</tt></a>.</td></tr><tr><td valign="top"><a href="#reg_other-3">reg_other/3</a></td><td>Equivalent to <a href="#reg_other-4"><tt>reg_other(Key, Pid, Value, [])</tt></a>.</td></tr><tr><td valign="top"><a href="#reg_other-4">reg_other/4</a></td><td>Register name or property to another process.</td></tr><tr><td valign="top"><a href="#reg_remote-2">reg_remote/2</a></td><td></td></tr><tr><td valign="top"><a href="#reg_remote-3">reg_remote/3</a></td><td></td></tr><tr><td valign="top"><a href="#reg_remote-4">reg_remote/4</a></td><td></td></tr><tr><td valign="top"><a href="#reg_shared-1">reg_shared/1</a></td><td>Register a resource, but don't tie it to a particular process.</td></tr><tr><td valign="top"><a href="#reg_shared-2">reg_shared/2</a></td><td>Register a resource, but don't tie it to a particular process.</td></tr><tr><td valign="top"><a href="#reg_shared-3">reg_shared/3</a></td><td></td></tr><tr><td valign="top"><a href="#register_name-2">register_name/2</a></td><td>Behaviour support callback.</td></tr><tr><td valign="top"><a href="#reset_counter-1">reset_counter/1</a></td><td>Reads and resets a counter in a "thread-safe" way.</td></tr><tr><td valign="top"><a href="#select-1">select/1</a></td><td>Perform a select operation on the process registry.</td></tr><tr><td valign="top"><a href="#select-2">select/2</a></td><td>Perform a select operation with limited context on the process registry.</td></tr><tr><td valign="top"><a href="#select-3">select/3</a></td><td>Like <a docgen-rel="seemfa" docgen-href="#select/2" href="#select-2"><code>select/2</code></a> but returns Limit objects at a time.</td></tr><tr><td valign="top"><a href="#select_count-1">select_count/1</a></td><td>Equivalent to <a href="#select_count-2"><tt>select_count(all, Pat)</tt></a>.</td></tr><tr><td valign="top"><a href="#select_count-2">select_count/2</a></td><td>Perform a select_count operation on the process registry.</td></tr><tr><td valign="top"><a href="#send-2">send/2</a></td><td>Sends a message to the process, or processes, corresponding to Key.</td></tr><tr><td valign="top"><a href="#set_attributes-2">set_attributes/2</a></td><td>Add/modify <code>{Key, Value}</code> attributes associated with a registration.</td></tr><tr><td valign="top"><a href="#set_attributes_shared-2">set_attributes_shared/2</a></td><td>Add/modify <code>{Key, Value}</code> attributes associated with a shared registration.</td></tr><tr><td valign="top"><a href="#set_env-5">set_env/5</a></td><td>Updates the cached value as well as underlying environment.</td></tr><tr><td valign="top"><a href="#set_value-2">set_value/2</a></td><td>Sets the value of the registration given by Key.</td></tr><tr><td valign="top"><a href="#set_value_remote-3">set_value_remote/3</a></td><td></td></tr><tr><td valign="top"><a href="#set_value_shared-2">set_value_shared/2</a></td><td>Sets the value of the shared registration given by Key.</td></tr><tr><td valign="top"><a href="#start_link-0">start_link/0</a></td><td>Starts the gproc server.</td></tr><tr><td valign="top"><a href="#table-0">table/0</a></td><td>Equivalent to <a href="#table-1"><tt>table({all, all})</tt></a>.</td></tr><tr><td valign="top"><a href="#table-1">table/1</a></td><td>Equivalent to <a href="#table-2"><tt>table(Context, [])</tt></a>.</td></tr><tr><td valign="top"><a href="#table-2">table/2</a></td><td>QLC table generator for the gproc registry.</td></tr><tr><td valign="top"><a href="#unreg-1">unreg/1</a></td><td>Unregister a name or property.</td></tr><tr><td valign="top"><a href="#unreg_other-2">unreg_other/2</a></td><td>Unregister a name registered to another process.</td></tr><tr><td valign="top"><a href="#unreg_remote-2">unreg_remote/2</a></td><td></td></tr><tr><td valign="top"><a href="#unreg_shared-1">unreg_shared/1</a></td><td>Unregister a shared resource.</td></tr><tr><td valign="top"><a href="#unregister_name-1">unregister_name/1</a></td><td>Equivalent to <tt>unreg / 1</tt>.</td></tr><tr><td valign="top"><a href="#update_counter-2">update_counter/2</a></td><td>Updates the counter registered as Key for the current process.</td></tr><tr><td valign="top"><a href="#update_counter-3">update_counter/3</a></td><td></td></tr><tr><td valign="top"><a href="#update_counter_remote-3">update_counter_remote/3</a></td><td></td></tr><tr><td valign="top"><a href="#update_counters-2">update_counters/2</a></td><td>Update a list of counters.</td></tr><tr><td valign="top"><a href="#update_shared_counter-2">update_shared_counter/2</a></td><td>Updates the shared counter registered as Key.</td></tr><tr><td valign="top"><a href="#where-1">where/1</a></td><td>Returns the pid registered as Key.</td></tr><tr><td valign="top"><a href="#whereis_name-1">whereis_name/1</a></td><td>Equivalent to <tt>where / 1</tt>.</td></tr><tr><td valign="top"><a href="#wide_await-3">wide_await/3</a></td><td>Wait for a local name to be registered on any of <code>Nodes</code>.</td></tr></table>
 
 
 <a name="functions"></a>
@@ -559,7 +579,7 @@ process instead of the current process. Also see [`ensure_reg/3`](#ensure_reg-3)
 ### first/1 ###
 
 <pre><code>
-first(Context::<a href="#type-context">context()</a>) -&gt; <a href="#type-key">key()</a> | '$end_of_table'
+first(Context::<a href="#type-context">context()</a>) -&gt; <a href="#type-key">key()</a> | $end_of_table
 </code></pre>
 <br />
 
@@ -853,7 +873,7 @@ same as [`http://www.erlang.org/doc/man/erlang.html#process_info-2`](http://www.
 ### last/1 ###
 
 <pre><code>
-last(Context::<a href="#type-context">context()</a>) -&gt; <a href="#type-key">key()</a> | '$end_of_table'
+last(Context::<a href="#type-context">context()</a>) -&gt; <a href="#type-key">key()</a> | $end_of_table
 </code></pre>
 <br />
 
@@ -917,6 +937,20 @@ Equivalent to [`lookup_values({p, g, Property})`](#lookup_values-1).
 Look up all global (non-unique) instances of a given Property.
 Returns a list of {Pid, Value} tuples for all matching objects.
 
+<a name="lookup_global_resources-1"></a>
+
+### lookup_global_resources/1 ###
+
+<pre><code>
+lookup_global_resources(Resource::any()) -&gt; [{pid(), Value::integer()}]
+</code></pre>
+<br />
+
+Equivalent to [`lookup_values({r, g, Resource})`](#lookup_values-1).
+
+Look up all global (non-unique) instances of a given Resource.
+Returns a list of {Pid, Value} tuples for all matching objects.
+
 <a name="lookup_local_aggr_counter-1"></a>
 
 ### lookup_local_aggr_counter/1 ###
@@ -970,6 +1004,20 @@ lookup_local_properties(Property::any()) -&gt; [{pid(), Value}]
 Equivalent to [`lookup_values({p, l, Property})`](#lookup_values-1).
 
 Look up all local (non-unique) instances of a given Property.
+Returns a list of {Pid, Value} tuples for all matching objects.
+
+<a name="lookup_local_resources-1"></a>
+
+### lookup_local_resources/1 ###
+
+<pre><code>
+lookup_local_resources(Resource::any()) -&gt; [{pid(), Value::integer()}]
+</code></pre>
+<br />
+
+Equivalent to [`lookup_values({r, l, Resource})`](#lookup_values-1).
+
+Look up all local (non-unique) instances of a given Resource.
 Returns a list of {Pid, Value} tuples for all matching objects.
 
 <a name="lookup_pid-1"></a>
@@ -1131,7 +1179,7 @@ The caller can expect to receive a message,
 ### next/2 ###
 
 <pre><code>
-next(Context::<a href="#type-context">context()</a>, Key::<a href="#type-key">key()</a>) -&gt; <a href="#type-key">key()</a> | '$end_of_table'
+next(Context::<a href="#type-context">context()</a>, Key::<a href="#type-key">key()</a>) -&gt; <a href="#type-key">key()</a> | $end_of_table
 </code></pre>
 <br />
 
@@ -1145,7 +1193,7 @@ The registry behaves as an ordered_set table.
 ### prev/2 ###
 
 <pre><code>
-prev(Context::<a href="#type-context">context()</a>, Key::<a href="#type-key">key()</a>) -&gt; <a href="#type-key">key()</a> | '$end_of_table'
+prev(Context::<a href="#type-context">context()</a>, Key::<a href="#type-key">key()</a>) -&gt; <a href="#type-key">key()</a> | $end_of_table
 </code></pre>
 <br />
 
@@ -1204,10 +1252,16 @@ and behaves roughly as an ets counter (see [`update_counter/2`](#update_counter-
 reflects the sum of all counter objects with the same name in the given
 scope. The initial value for an aggregated counter must be `undefined`.
 * `r` - 'resource property', behaves like a property, but can be tracked
-with a 'resource counter'.
+with a 'resource counter'. Note that using an `rc` wildcard name
+pattern (see below) for a resource property is not allowed.
 * `rc` - 'resource counter', tracks the number of resource properties
 with the same name. When the resource count reaches `0`, any triggers
 specified using an `on_zero` attribute may be executed (see below).
+If `Name` is a tuple, the last element of the name can contain a
+wildcard, using the symbol `'\\_'`. This will make the resource
+counter keep track of any resources where all elements match except
+the last position. For example, `{rc,l,{a,b,'\\_'}}` would keep
+track of both `{r,l,{a,b,1}}` and `{r,l,{a,b,2}}`.
 
 On-zero triggers:
 
@@ -1306,6 +1360,24 @@ Only the following resource types can be registered through this function:
 * `r`  - resource properties
 * `rc` - resource counters
 
+<a name="reg_remote-2"></a>
+
+### reg_remote/2 ###
+
+`reg_remote(Node, Key) -> any()`
+
+<a name="reg_remote-3"></a>
+
+### reg_remote/3 ###
+
+`reg_remote(Node, Key, Value) -> any()`
+
+<a name="reg_remote-4"></a>
+
+### reg_remote/4 ###
+
+`reg_remote(Node, Key, Value, Attrs) -> any()`
+
 <a name="reg_shared-1"></a>
 
 ### reg_shared/1 ###
@@ -1386,7 +1458,7 @@ appropriate value type.
 ### select/1 ###
 
 <pre><code>
-select(Continuation::Arg) -&gt; [Match] | {[Match], Continuation} | '$end_of_table'
+select(Continuation::Arg) -&gt; [Match] | {[Match], Continuation} | $end_of_table
 </code></pre>
 
 <ul class="definitions"><li><code>Arg = Continuation | <a href="#type-sel_pattern">sel_pattern()</a></code></li><li><code>Match = {Key, Pid, Value}</code></li></ul>
@@ -1396,7 +1468,7 @@ Perform a select operation on the process registry
 When Arg = Contination, resume a gproc:select/1 operation
 (see [ets:select/1](http://www.erlang.org/doc/man/ets.html#select-1)
 
-When Arg = <code><a href="#type-sel_pattern">sel_pattern()</a></code>, this function executes a select operation,
+When Arg = <code><a href="#type-sel_pattern" docgen-rel="seetype" docgen-href="#sel_pattern/0">sel_pattern()</a></code>, this function executes a select operation,
 emulating ets:select/1
 
 [`select/2`](#select-2) offers the opportunity to narrow the search
@@ -1408,7 +1480,7 @@ still limit the select operation so that scanning the entire table is avoided.
 The physical representation in the registry may differ from the above,
 but the select patterns are transformed appropriately. The logical
 representation for the gproc select operations is given by
-<code><a href="#type-headpat">headpat()</a></code>.
+<code><a href="#type-headpat" docgen-rel="seetype" docgen-href="#headpat/0">headpat()</a></code>.
 
 <a name="select-2"></a>
 
@@ -1438,7 +1510,7 @@ variable substitution and ensure that the scan is limited.
 ### select/3 ###
 
 <pre><code>
-select(Context::<a href="#type-context">context()</a>, Pat::<a href="#type-sel_patten">sel_patten()</a>, Limit::integer()) -&gt; {[Match], Continuation} | '$end_of_table'
+select(Context::<a href="#type-context">context()</a>, Pat::<a href="#type-sel_patten">sel_patten()</a>, Limit::integer()) -&gt; {[Match], Continuation} | $end_of_table
 </code></pre>
 <br />
 
@@ -1563,6 +1635,12 @@ If it doesn't, this function will exit.
 Value can be any term, unless the object is a counter, in which case
 it must be an integer.
 
+<a name="set_value_remote-3"></a>
+
+### set_value_remote/3 ###
+
+`set_value_remote(Node, Key, Value) -> any()`
+
 <a name="set_value_shared-2"></a>
 
 ### set_value_shared/2 ###
@@ -1663,6 +1741,12 @@ This function is equivalent to [`unreg/1`](#unreg-1), but specifies another
 process as the holder of the registration. An exception is raised if the
 name or property is not registered to the given process.
 
+<a name="unreg_remote-2"></a>
+
+### unreg_remote/2 ###
+
+`unreg_remote(Node, Key) -> any()`
+
 <a name="unreg_shared-1"></a>
 
 ### unreg_shared/1 ###
@@ -1687,7 +1771,7 @@ Equivalent to `unreg / 1`.
 ### update_counter/2 ###
 
 <pre><code>
-update_counter(Key::<a href="#type-key">key()</a>, Incr::<a href="#type-increment">increment()</a>) -&gt; integer()
+update_counter(Key::<a href="#type-key">key()</a>, Incr::<a href="#type-increment">increment()</a>) -&gt; integer() | [integer()]
 </code></pre>
 <br />
 
@@ -1714,6 +1798,12 @@ appropriate value type.
 ### update_counter/3 ###
 
 `update_counter(Key, Pid, Incr) -> any()`
+
+<a name="update_counter_remote-3"></a>
+
+### update_counter_remote/3 ###
+
+`update_counter_remote(Node, Key, Incr) -> any()`
 
 <a name="update_counters-2"></a>
 

--- a/doc/gproc_dist.md
+++ b/doc/gproc_dist.md
@@ -7,8 +7,6 @@
 
 Extended process registry.
 
-__Behaviours:__ [`gen_leader`](gen_leader.md).
-
 __Authors:__ Ulf Wiger ([`ulf@wiger.net`](mailto:ulf@wiger.net)).
 
 <a name="description"></a>

--- a/doc/gproc_lib.md
+++ b/doc/gproc_lib.md
@@ -22,7 +22,7 @@ For a detailed description, see gproc/doc/erlang07-wiger.pdf.
 ## Function Index ##
 
 
-<table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#add_monitor-4">add_monitor/4</a></td><td></td></tr><tr><td valign="top"><a href="#await-3">await/3</a></td><td></td></tr><tr><td valign="top"><a href="#dbg-1">dbg/1</a></td><td></td></tr><tr><td valign="top"><a href="#decrement_resource_count-2">decrement_resource_count/2</a></td><td></td></tr><tr><td valign="top"><a href="#do_set_counter_value-3">do_set_counter_value/3</a></td><td></td></tr><tr><td valign="top"><a href="#do_set_value-3">do_set_value/3</a></td><td></td></tr><tr><td valign="top"><a href="#does_pid_monitor-2">does_pid_monitor/2</a></td><td></td></tr><tr><td valign="top"><a href="#ensure_monitor-2">ensure_monitor/2</a></td><td></td></tr><tr><td valign="top"><a href="#followers-1">followers/1</a></td><td></td></tr><tr><td valign="top"><a href="#insert_attr-4">insert_attr/4</a></td><td></td></tr><tr><td valign="top"><a href="#insert_many-4">insert_many/4</a></td><td></td></tr><tr><td valign="top"><a href="#insert_reg-4">insert_reg/4</a></td><td></td></tr><tr><td valign="top"><a href="#insert_reg-5">insert_reg/5</a></td><td></td></tr><tr><td valign="top"><a href="#monitors-1">monitors/1</a></td><td></td></tr><tr><td valign="top"><a href="#notify-2">notify/2</a></td><td></td></tr><tr><td valign="top"><a href="#notify-3">notify/3</a></td><td></td></tr><tr><td valign="top"><a href="#remove_many-4">remove_many/4</a></td><td></td></tr><tr><td valign="top"><a href="#remove_monitor-3">remove_monitor/3</a></td><td></td></tr><tr><td valign="top"><a href="#remove_monitor_pid-2">remove_monitor_pid/2</a></td><td></td></tr><tr><td valign="top"><a href="#remove_monitors-3">remove_monitors/3</a></td><td></td></tr><tr><td valign="top"><a href="#remove_reg-3">remove_reg/3</a></td><td></td></tr><tr><td valign="top"><a href="#remove_reg-4">remove_reg/4</a></td><td></td></tr><tr><td valign="top"><a href="#remove_reverse_mapping-3">remove_reverse_mapping/3</a></td><td></td></tr><tr><td valign="top"><a href="#remove_reverse_mapping-4">remove_reverse_mapping/4</a></td><td></td></tr><tr><td valign="top"><a href="#remove_wait-4">remove_wait/4</a></td><td></td></tr><tr><td valign="top"><a href="#standbys-1">standbys/1</a></td><td></td></tr><tr><td valign="top"><a href="#update_aggr_counter-3">update_aggr_counter/3</a></td><td></td></tr><tr><td valign="top"><a href="#update_counter-3">update_counter/3</a></td><td></td></tr><tr><td valign="top"><a href="#valid_opts-2">valid_opts/2</a></td><td></td></tr></table>
+<table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#add_monitor-4">add_monitor/4</a></td><td></td></tr><tr><td valign="top"><a href="#await-3">await/3</a></td><td></td></tr><tr><td valign="top"><a href="#dbg-1">dbg/1</a></td><td></td></tr><tr><td valign="top"><a href="#decrement_resource_count-2">decrement_resource_count/2</a></td><td></td></tr><tr><td valign="top"><a href="#do_set_counter_value-3">do_set_counter_value/3</a></td><td></td></tr><tr><td valign="top"><a href="#do_set_value-3">do_set_value/3</a></td><td></td></tr><tr><td valign="top"><a href="#does_pid_monitor-2">does_pid_monitor/2</a></td><td></td></tr><tr><td valign="top"><a href="#ensure_monitor-2">ensure_monitor/2</a></td><td></td></tr><tr><td valign="top"><a href="#followers-1">followers/1</a></td><td></td></tr><tr><td valign="top"><a href="#insert_attr-4">insert_attr/4</a></td><td></td></tr><tr><td valign="top"><a href="#insert_many-4">insert_many/4</a></td><td></td></tr><tr><td valign="top"><a href="#insert_reg-4">insert_reg/4</a></td><td></td></tr><tr><td valign="top"><a href="#insert_reg-5">insert_reg/5</a></td><td></td></tr><tr><td valign="top"><a href="#monitors-1">monitors/1</a></td><td></td></tr><tr><td valign="top"><a href="#notify-2">notify/2</a></td><td></td></tr><tr><td valign="top"><a href="#notify-3">notify/3</a></td><td></td></tr><tr><td valign="top"><a href="#remove_many-4">remove_many/4</a></td><td></td></tr><tr><td valign="top"><a href="#remove_monitor-3">remove_monitor/3</a></td><td></td></tr><tr><td valign="top"><a href="#remove_monitor_pid-2">remove_monitor_pid/2</a></td><td></td></tr><tr><td valign="top"><a href="#remove_monitors-3">remove_monitors/3</a></td><td></td></tr><tr><td valign="top"><a href="#remove_reg-3">remove_reg/3</a></td><td></td></tr><tr><td valign="top"><a href="#remove_reg-4">remove_reg/4</a></td><td></td></tr><tr><td valign="top"><a href="#remove_reverse_mapping-3">remove_reverse_mapping/3</a></td><td></td></tr><tr><td valign="top"><a href="#remove_reverse_mapping-4">remove_reverse_mapping/4</a></td><td></td></tr><tr><td valign="top"><a href="#remove_wait-4">remove_wait/4</a></td><td></td></tr><tr><td valign="top"><a href="#standbys-1">standbys/1</a></td><td></td></tr><tr><td valign="top"><a href="#update_aggr_counter-3">update_aggr_counter/3</a></td><td></td></tr><tr><td valign="top"><a href="#update_counter-3">update_counter/3</a></td><td></td></tr><tr><td valign="top"><a href="#valid_key-1">valid_key/1</a></td><td></td></tr><tr><td valign="top"><a href="#valid_opts-2">valid_opts/2</a></td><td></td></tr></table>
 
 
 <a name="functions"></a>
@@ -94,7 +94,7 @@ For a detailed description, see gproc/doc/erlang07-wiger.pdf.
 ### insert_many/4 ###
 
 <pre><code>
-insert_many(T::<a href="gproc.md#type-type">gproc:type()</a>, Scope::<a href="gproc.md#type-scope">gproc:scope()</a>, KVL::[{<a href="gproc.md#type-key">gproc:key()</a>, any()}], Pid::pid()) -&gt; {true, list()} | false
+insert_many(T::<a href="http://www.erlang.org/doc/man/gproc.html#type-type">gproc:type()</a>, Scope::<a href="http://www.erlang.org/doc/man/gproc.html#type-scope">gproc:scope()</a>, KVL::[{<a href="http://www.erlang.org/doc/man/gproc.html#type-key">gproc:key()</a>, any()}], Pid::pid()) -&gt; {true, list()} | false
 </code></pre>
 <br />
 
@@ -103,7 +103,7 @@ insert_many(T::<a href="gproc.md#type-type">gproc:type()</a>, Scope::<a href="gp
 ### insert_reg/4 ###
 
 <pre><code>
-insert_reg(K::<a href="gproc.md#type-key">gproc:key()</a>, Value::any(), Pid::pid() | shared, Scope::<a href="gproc.md#type-scope">gproc:scope()</a>) -&gt; boolean()
+insert_reg(K::<a href="http://www.erlang.org/doc/man/gproc.html#type-key">gproc:key()</a>, Value::any(), Pid::pid() | shared, Scope::<a href="http://www.erlang.org/doc/man/gproc.html#type-scope">gproc:scope()</a>) -&gt; boolean()
 </code></pre>
 <br />
 
@@ -202,6 +202,12 @@ insert_reg(K::<a href="gproc.md#type-key">gproc:key()</a>, Value::any(), Pid::pi
 ### update_counter/3 ###
 
 `update_counter(Key, Incr, Pid) -> any()`
+
+<a name="valid_key-1"></a>
+
+### valid_key/1 ###
+
+`valid_key(Key) -> any()`
 
 <a name="valid_opts-2"></a>
 

--- a/doc/gproc_ps.md
+++ b/doc/gproc_ps.md
@@ -93,7 +93,7 @@ status() = 1 | 0
 ## Function Index ##
 
 
-<table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#change_cond-3">change_cond/3</a></td><td>Change the condition specification of an existing subscription.</td></tr><tr><td valign="top"><a href="#change_cond_remote-3">change_cond_remote/3</a></td><td></td></tr><tr><td valign="top"><a href="#create_single-2">create_single/2</a></td><td>Creates a single-shot subscription entry for Event.</td></tr><tr><td valign="top"><a href="#create_single_remote-2">create_single_remote/2</a></td><td></td></tr><tr><td valign="top"><a href="#delete_single-2">delete_single/2</a></td><td>Deletes the single-shot subscription for Event.</td></tr><tr><td valign="top"><a href="#delete_single_remote-2">delete_single_remote/2</a></td><td></td></tr><tr><td valign="top"><a href="#disable_single-2">disable_single/2</a></td><td>Disables the single-shot subscription for Event.</td></tr><tr><td valign="top"><a href="#disable_single_remote-2">disable_single_remote/2</a></td><td></td></tr><tr><td valign="top"><a href="#enable_single-2">enable_single/2</a></td><td>Enables the single-shot subscription for Event.</td></tr><tr><td valign="top"><a href="#enable_single_remote-2">enable_single_remote/2</a></td><td></td></tr><tr><td valign="top"><a href="#list_singles-2">list_singles/2</a></td><td>Lists all single-shot subscribers of Event, together with their status.</td></tr><tr><td valign="top"><a href="#list_subs-2">list_subs/2</a></td><td>List the pids of all processes subscribing to <code>Event</code></td></tr><tr><td valign="top"><a href="#notify_single_if_true-4">notify_single_if_true/4</a></td><td>Create/enable a single subscription for event; notify at once if F() -> true.</td></tr><tr><td valign="top"><a href="#publish-3">publish/3</a></td><td>Publish the message <code>Msg</code> to all subscribers of <code>Event</code></td></tr><tr><td valign="top"><a href="#publish_cond-3">publish_cond/3</a></td><td>Publishes the message <code>Msg</code> to conditional subscribers of <code>Event</code></td></tr><tr><td valign="top"><a href="#subscribe-2">subscribe/2</a></td><td>Subscribe to events of type <code>Event</code></td></tr><tr><td valign="top"><a href="#subscribe_cond-3">subscribe_cond/3</a></td><td>Subscribe conditionally to events of type <code>Event</code></td></tr><tr><td valign="top"><a href="#subscribe_cond_remote-3">subscribe_cond_remote/3</a></td><td></td></tr><tr><td valign="top"><a href="#subscribe_remote-2">subscribe_remote/2</a></td><td>Subscribe from a remote node.</td></tr><tr><td valign="top"><a href="#tell_singles-3">tell_singles/3</a></td><td>Publish <code>Msg</code> to all single-shot subscribers of <code>Event</code></td></tr><tr><td valign="top"><a href="#unsubscribe-2">unsubscribe/2</a></td><td>Remove subscribtion created using <code>subscribe(Scope, Event)</code></td></tr><tr><td valign="top"><a href="#unsubscribe_remote-2">unsubscribe_remote/2</a></td><td></td></tr></table>
+<table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#change_cond-3">change_cond/3</a></td><td>Change the condition specification of an existing subscription.</td></tr><tr><td valign="top"><a href="#change_cond_remote-3">change_cond_remote/3</a></td><td>Change the condition spec of a subscription created from a remote node.</td></tr><tr><td valign="top"><a href="#create_single-2">create_single/2</a></td><td>Creates a single-shot subscription entry for Event.</td></tr><tr><td valign="top"><a href="#create_single_remote-2">create_single_remote/2</a></td><td>Create a local single-shot subscription from a remote node.</td></tr><tr><td valign="top"><a href="#delete_single-2">delete_single/2</a></td><td>Deletes the single-shot subscription for Event.</td></tr><tr><td valign="top"><a href="#delete_single_remote-2">delete_single_remote/2</a></td><td>Delete a single-shot subscription created from a remote node.</td></tr><tr><td valign="top"><a href="#disable_single-2">disable_single/2</a></td><td>Disables the single-shot subscription for Event.</td></tr><tr><td valign="top"><a href="#disable_single_remote-2">disable_single_remote/2</a></td><td>Disable a single-shot subscription created from a remote node.</td></tr><tr><td valign="top"><a href="#enable_single-2">enable_single/2</a></td><td>Enables the single-shot subscription for Event.</td></tr><tr><td valign="top"><a href="#enable_single_remote-2">enable_single_remote/2</a></td><td>Enable a single-shot subscription created from a remote node.</td></tr><tr><td valign="top"><a href="#list_singles-2">list_singles/2</a></td><td>Lists all single-shot subscribers of Event, together with their status.</td></tr><tr><td valign="top"><a href="#list_subs-2">list_subs/2</a></td><td>List the pids of all processes subscribing to <code>Event</code></td></tr><tr><td valign="top"><a href="#notify_single_if_true-4">notify_single_if_true/4</a></td><td>Create/enable a single subscription for event; notify at once if F() -> true.</td></tr><tr><td valign="top"><a href="#publish-3">publish/3</a></td><td>Publish the message <code>Msg</code> to all subscribers of <code>Event</code></td></tr><tr><td valign="top"><a href="#publish_cond-3">publish_cond/3</a></td><td>Publishes the message <code>Msg</code> to conditional subscribers of <code>Event</code></td></tr><tr><td valign="top"><a href="#subscribe-2">subscribe/2</a></td><td>Subscribe to events of type <code>Event</code></td></tr><tr><td valign="top"><a href="#subscribe_cond-3">subscribe_cond/3</a></td><td>Subscribe conditionally to events of type <code>Event</code></td></tr><tr><td valign="top"><a href="#subscribe_cond_remote-3">subscribe_cond_remote/3</a></td><td>Subscribe conditionally from a remote node.</td></tr><tr><td valign="top"><a href="#subscribe_remote-2">subscribe_remote/2</a></td><td>Subscribe from a remote node.</td></tr><tr><td valign="top"><a href="#tell_singles-3">tell_singles/3</a></td><td>Publish <code>Msg</code> to all single-shot subscribers of <code>Event</code></td></tr><tr><td valign="top"><a href="#unsubscribe-2">unsubscribe/2</a></td><td>Remove subscription created using <code>subscribe(Scope, Event)</code></td></tr><tr><td valign="top"><a href="#unsubscribe_remote-2">unsubscribe_remote/2</a></td><td>Remove subscription created from a remote node.</td></tr></table>
 
 
 <a name="functions"></a>
@@ -128,6 +128,8 @@ change_cond_remote(Node::node(), Event::<a href="#type-event">event()</a>, Spec:
 </code></pre>
 <br />
 
+Change the condition spec of a subscription created from a remote node
+
 <a name="create_single-2"></a>
 
 ### create_single/2 ###
@@ -156,7 +158,12 @@ as it has delivered a message.
 
 ### create_single_remote/2 ###
 
-`create_single_remote(Node, Event) -> any()`
+<pre><code>
+create_single_remote(Node::node(), Event::<a href="#type-event">event()</a>) -&gt; true
+</code></pre>
+<br />
+
+Create a local single-shot subscription from a remote node
 
 <a name="delete_single-2"></a>
 
@@ -176,7 +183,12 @@ An exception will be raised if there is no such subscription.
 
 ### delete_single_remote/2 ###
 
-`delete_single_remote(Node, Event) -> any()`
+<pre><code>
+delete_single_remote(Node::node(), Event::<a href="#type-event">event()</a>) -&gt; true
+</code></pre>
+<br />
+
+Delete a single-shot subscription created from a remote node
 
 <a name="disable_single-2"></a>
 
@@ -202,7 +214,12 @@ The return value indicates the previous status.
 
 ### disable_single_remote/2 ###
 
-`disable_single_remote(Node, Event) -> any()`
+<pre><code>
+disable_single_remote(Node::node(), Event::<a href="#type-event">event()</a>) -&gt; <a href="#type-status">status()</a>
+</code></pre>
+<br />
+
+Disable a single-shot subscription created from a remote node
 
 <a name="enable_single-2"></a>
 
@@ -230,7 +247,12 @@ The return value indicates the previous status.
 
 ### enable_single_remote/2 ###
 
-`enable_single_remote(Node, Event) -> any()`
+<pre><code>
+enable_single_remote(Node::node(), Event::<a href="#type-event">event()</a>) -&gt; <a href="#type-status">status()</a>
+</code></pre>
+<br />
+
+Enable a single-shot subscription created from a remote node
 
 <a name="list_singles-2"></a>
 
@@ -370,6 +392,8 @@ subscribe_cond_remote(Node::node(), Event::<a href="#type-event">event()</a>, Sp
 </code></pre>
 <br />
 
+Subscribe conditionally from a remote node
+
 <a name="subscribe_remote-2"></a>
 
 ### subscribe_remote/2 ###
@@ -414,7 +438,7 @@ unsubscribe(Scope::<a href="#type-scope">scope()</a>, Event::<a href="#type-even
 </code></pre>
 <br />
 
-Remove subscribtion created using `subscribe(Scope, Event)`
+Remove subscription created using `subscribe(Scope, Event)`
 
 This removes the property created through `subscribe/2`.
 
@@ -426,4 +450,6 @@ This removes the property created through `subscribe/2`.
 unsubscribe_remote(Node::node(), Event::<a href="#type-event">event()</a>) -&gt; true
 </code></pre>
 <br />
+
+Remove subscription created from a remote node
 

--- a/doc/gproc_ps.md
+++ b/doc/gproc_ps.md
@@ -31,6 +31,16 @@ counters to good effect.
 
 
 
+### <a name="type-cond_spec">cond_spec()</a> ###
+
+
+<pre><code>
+cond_spec() = undefined | <a href="http://www.erlang.org/doc/man/ets.html#type-match_spec">ets:match_spec()</a>
+</code></pre>
+
+
+
+
 ### <a name="type-event">event()</a> ###
 
 
@@ -46,6 +56,16 @@ event() = any()
 
 <pre><code>
 msg() = any()
+</code></pre>
+
+
+
+
+### <a name="type-notification">notification()</a> ###
+
+
+<pre><code>
+notification() = {?ETag, <a href="#type-event">event()</a>, <a href="#type-msg">msg()</a>}
 </code></pre>
 
 
@@ -73,7 +93,7 @@ status() = 1 | 0
 ## Function Index ##
 
 
-<table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#change_cond-3">change_cond/3</a></td><td>Change the condition specification of an existing subscription.</td></tr><tr><td valign="top"><a href="#create_single-2">create_single/2</a></td><td>Creates a single-shot subscription entry for Event.</td></tr><tr><td valign="top"><a href="#delete_single-2">delete_single/2</a></td><td>Deletes the single-shot subscription for Event.</td></tr><tr><td valign="top"><a href="#disable_single-2">disable_single/2</a></td><td>Disables the single-shot subscription for Event.</td></tr><tr><td valign="top"><a href="#enable_single-2">enable_single/2</a></td><td>Enables the single-shot subscription for Event.</td></tr><tr><td valign="top"><a href="#list_singles-2">list_singles/2</a></td><td>Lists all single-shot subscribers of Event, together with their status.</td></tr><tr><td valign="top"><a href="#list_subs-2">list_subs/2</a></td><td>List the pids of all processes subscribing to <code>Event</code></td></tr><tr><td valign="top"><a href="#notify_single_if_true-4">notify_single_if_true/4</a></td><td>Create/enable a single subscription for event; notify at once if F() -> true.</td></tr><tr><td valign="top"><a href="#publish-3">publish/3</a></td><td>Publish the message <code>Msg</code> to all subscribers of <code>Event</code></td></tr><tr><td valign="top"><a href="#publish_cond-3">publish_cond/3</a></td><td>Publishes the message <code>Msg</code> to conditional subscribers of <code>Event</code></td></tr><tr><td valign="top"><a href="#subscribe-2">subscribe/2</a></td><td>Subscribe to events of type <code>Event</code></td></tr><tr><td valign="top"><a href="#subscribe_cond-3">subscribe_cond/3</a></td><td>Subscribe conditionally to events of type <code>Event</code></td></tr><tr><td valign="top"><a href="#tell_singles-3">tell_singles/3</a></td><td>Publish <code>Msg</code> to all single-shot subscribers of <code>Event</code></td></tr><tr><td valign="top"><a href="#unsubscribe-2">unsubscribe/2</a></td><td>Remove subscribtion created using <code>subscribe(Scope, Event)</code></td></tr></table>
+<table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#change_cond-3">change_cond/3</a></td><td>Change the condition specification of an existing subscription.</td></tr><tr><td valign="top"><a href="#change_cond_remote-3">change_cond_remote/3</a></td><td></td></tr><tr><td valign="top"><a href="#create_single-2">create_single/2</a></td><td>Creates a single-shot subscription entry for Event.</td></tr><tr><td valign="top"><a href="#create_single_remote-2">create_single_remote/2</a></td><td></td></tr><tr><td valign="top"><a href="#delete_single-2">delete_single/2</a></td><td>Deletes the single-shot subscription for Event.</td></tr><tr><td valign="top"><a href="#delete_single_remote-2">delete_single_remote/2</a></td><td></td></tr><tr><td valign="top"><a href="#disable_single-2">disable_single/2</a></td><td>Disables the single-shot subscription for Event.</td></tr><tr><td valign="top"><a href="#disable_single_remote-2">disable_single_remote/2</a></td><td></td></tr><tr><td valign="top"><a href="#enable_single-2">enable_single/2</a></td><td>Enables the single-shot subscription for Event.</td></tr><tr><td valign="top"><a href="#enable_single_remote-2">enable_single_remote/2</a></td><td></td></tr><tr><td valign="top"><a href="#list_singles-2">list_singles/2</a></td><td>Lists all single-shot subscribers of Event, together with their status.</td></tr><tr><td valign="top"><a href="#list_subs-2">list_subs/2</a></td><td>List the pids of all processes subscribing to <code>Event</code></td></tr><tr><td valign="top"><a href="#notify_single_if_true-4">notify_single_if_true/4</a></td><td>Create/enable a single subscription for event; notify at once if F() -> true.</td></tr><tr><td valign="top"><a href="#publish-3">publish/3</a></td><td>Publish the message <code>Msg</code> to all subscribers of <code>Event</code></td></tr><tr><td valign="top"><a href="#publish_cond-3">publish_cond/3</a></td><td>Publishes the message <code>Msg</code> to conditional subscribers of <code>Event</code></td></tr><tr><td valign="top"><a href="#subscribe-2">subscribe/2</a></td><td>Subscribe to events of type <code>Event</code></td></tr><tr><td valign="top"><a href="#subscribe_cond-3">subscribe_cond/3</a></td><td>Subscribe conditionally to events of type <code>Event</code></td></tr><tr><td valign="top"><a href="#subscribe_cond_remote-3">subscribe_cond_remote/3</a></td><td></td></tr><tr><td valign="top"><a href="#subscribe_remote-2">subscribe_remote/2</a></td><td>Subscribe from a remote node.</td></tr><tr><td valign="top"><a href="#tell_singles-3">tell_singles/3</a></td><td>Publish <code>Msg</code> to all single-shot subscribers of <code>Event</code></td></tr><tr><td valign="top"><a href="#unsubscribe-2">unsubscribe/2</a></td><td>Remove subscribtion created using <code>subscribe(Scope, Event)</code></td></tr><tr><td valign="top"><a href="#unsubscribe_remote-2">unsubscribe_remote/2</a></td><td></td></tr></table>
 
 
 <a name="functions"></a>
@@ -85,7 +105,7 @@ status() = 1 | 0
 ### change_cond/3 ###
 
 <pre><code>
-change_cond(Scope::<a href="#type-scope">scope()</a>, Event::<a href="#type-event">event()</a>, Spec::undefined | <a href="ets.md#type-match_spec">ets:match_spec()</a>) -&gt; true
+change_cond(Scope::<a href="#type-scope">scope()</a>, Event::<a href="#type-event">event()</a>, Spec::<a href="#type-cond_spec">cond_spec()</a>) -&gt; true
 </code></pre>
 <br />
 
@@ -98,6 +118,15 @@ the subscription doesn't already exist.
 Note that this function can also be used to change a conditional subscription
 to an unconditional one (by setting `Spec = undefined`), or a 'normal'
 subscription to a conditional one.
+
+<a name="change_cond_remote-3"></a>
+
+### change_cond_remote/3 ###
+
+<pre><code>
+change_cond_remote(Node::node(), Event::<a href="#type-event">event()</a>, Spec::<a href="#type-cond_spec">cond_spec()</a>) -&gt; true
+</code></pre>
+<br />
 
 <a name="create_single-2"></a>
 
@@ -123,6 +152,12 @@ Counters are used in this case, since they can be atomically updated by both the
 subscriber (owner) and publisher. The publisher sets the counter value to `0` as soon
 as it has delivered a message.
 
+<a name="create_single_remote-2"></a>
+
+### create_single_remote/2 ###
+
+`create_single_remote(Node, Event) -> any()`
+
 <a name="delete_single-2"></a>
 
 ### delete_single/2 ###
@@ -136,6 +171,12 @@ Deletes the single-shot subscription for Event
 
 This function deletes the counter entry representing the single-shot description.
 An exception will be raised if there is no such subscription.
+
+<a name="delete_single_remote-2"></a>
+
+### delete_single_remote/2 ###
+
+`delete_single_remote(Node, Event) -> any()`
 
 <a name="disable_single-2"></a>
 
@@ -156,6 +197,12 @@ This guarantees that the counter will have either the value 1 or 0, depending on
 update happened last.
 
 The return value indicates the previous status.
+
+<a name="disable_single_remote-2"></a>
+
+### disable_single_remote/2 ###
+
+`disable_single_remote(Node, Event) -> any()`
 
 <a name="enable_single-2"></a>
 
@@ -178,6 +225,12 @@ This guarantees that the counter will have either the value 1 or 0, depending on
 update happened last.
 
 The return value indicates the previous status.
+
+<a name="enable_single_remote-2"></a>
+
+### enable_single_remote/2 ###
+
+`enable_single_remote(Node, Event) -> any()`
 
 <a name="list_singles-2"></a>
 
@@ -223,7 +276,7 @@ immediate test returns `false`.
 ### publish/3 ###
 
 <pre><code>
-publish(Scope::<a href="#type-scope">scope()</a>, Event::<a href="#type-event">event()</a>, Msg::<a href="#type-msg">msg()</a>) -&gt; ok
+publish(Scope::<a href="#type-scope">scope()</a>, Event::<a href="#type-event">event()</a>, Msg::<a href="#type-msg">msg()</a>) -&gt; <a href="#type-notification">notification()</a>
 </code></pre>
 <br />
 
@@ -241,7 +294,7 @@ property `{p,Scope,{gproc_ps_event,Event}}`.
 ### publish_cond/3 ###
 
 <pre><code>
-publish_cond(Scope::<a href="#type-scope">scope()</a>, Event::<a href="#type-event">event()</a>, Msg::<a href="#type-msg">msg()</a>) -&gt; <a href="#type-msg">msg()</a>
+publish_cond(Scope::<a href="#type-scope">scope()</a>, Event::<a href="#type-event">event()</a>, Msg::<a href="#type-msg">msg()</a>) -&gt; <a href="#type-notification">notification()</a>
 </code></pre>
 <br />
 
@@ -278,7 +331,7 @@ process.
 ### subscribe_cond/3 ###
 
 <pre><code>
-subscribe_cond(Scope::<a href="#type-scope">scope()</a>, Event::<a href="#type-event">event()</a>, Spec::undefined | <a href="ets.md#type-match_spec">ets:match_spec()</a>) -&gt; true
+subscribe_cond(Scope::<a href="#type-scope">scope()</a>, Event::<a href="#type-event">event()</a>, Spec::<a href="#type-cond_spec">cond_spec()</a>) -&gt; true
 </code></pre>
 <br />
 
@@ -307,6 +360,29 @@ equivalent.
 Note that, as with [`gproc:reg/1`](gproc.md#reg-1), this function will raise an
 exception if you try to subscribe to the same event twice from the same
 process.
+
+<a name="subscribe_cond_remote-3"></a>
+
+### subscribe_cond_remote/3 ###
+
+<pre><code>
+subscribe_cond_remote(Node::node(), Event::<a href="#type-event">event()</a>, Spec::<a href="#type-cond_spec">cond_spec()</a>) -&gt; true
+</code></pre>
+<br />
+
+<a name="subscribe_remote-2"></a>
+
+### subscribe_remote/2 ###
+
+<pre><code>
+subscribe_remote(Node::node(), Event::<a href="#type-event">event()</a>) -&gt; true
+</code></pre>
+<br />
+
+Subscribe from a remote node
+
+This functions as `gproc_ps:subscribe(Scope, Event)`, but is supposed to
+be called from a remote node (it will fail if called from a local process).
 
 <a name="tell_singles-3"></a>
 
@@ -341,4 +417,13 @@ unsubscribe(Scope::<a href="#type-scope">scope()</a>, Event::<a href="#type-even
 Remove subscribtion created using `subscribe(Scope, Event)`
 
 This removes the property created through `subscribe/2`.
+
+<a name="unsubscribe_remote-2"></a>
+
+### unsubscribe_remote/2 ###
+
+<pre><code>
+unsubscribe_remote(Node::node(), Event::<a href="#type-event">event()</a>) -&gt; true
+</code></pre>
+<br />
 

--- a/rebar.config
+++ b/rebar.config
@@ -2,29 +2,29 @@
 {erl_opts, [debug_info]}.
 
 {deps, [
-        {edown, ".*", {git, "https://github.com/uwiger/edown.git", "HEAD"}},
         {gen_leader, ".*",
          {git, "https://github.com/garret-smith/gen_leader_revival.git", "HEAD"}}
        ]}.
 
-{dialyzer_opts, [{warnings, [no_unused,
-                             no_improper_lists, no_fun_app, no_match,
-                             no_opaque, no_fail_call,
-                             error_handling, no_match,
-                             unmatched_returns,
-                             behaviours, underspecs]}]}.
+{dialyzer, [{plt_apps, all_deps},
+            {plt_extra_apps, [mnesia, runtime_tools, gen_leader]},
+            {warnings, [no_unused,
+                        no_improper_lists, no_fun_app, no_match,
+                        no_opaque, no_fail_call,
+                        error_handling, no_match,
+                        unmatched_returns, underspecs]}]}.
 {profiles, [
-            {doc, [
-                    {deps, [
-                             {edown, ".*",
-                              {git, "https://github.com/uwiger/edown.git", "HEAD"}}
+            {edown, [
+                     {deps, [
+                             {edown, "0.9.1"}
                             ]}
-                  , {edoc_opts, [{doclet, edown_doclet},
-                                 {app_default, "http://www.erlang.org/doc/man"},
-                                 {top_level_readme,
-                                  {"./README.md",
-                                   "http://github.com/uwiger/gproc"}}]}
-                  ]}
-            ]}.
+                    , {edoc_opts, [{doclet, edown_doclet},
+                                   {app_default, "http://www.erlang.org/doc/man"},
+                                   {branch, "master"},
+                                   {top_level_readme,
+                                    {"./README.md",
+                                     "http://github.com/uwiger/gproc", "master"}}]}
+                    ]}
+           ]}.
 
 {shell, [{apps, [gproc]}]}.

--- a/src/gproc.erl
+++ b/src/gproc.erl
@@ -50,7 +50,6 @@
 -export([start_link/0,
          reg/1, reg/2, reg/3, unreg/1, set_attributes/2,
          reg_other/2, reg_other/3, reg_other/4, unreg_other/2,
-         reg_remote/2, reg_remote/3, reg_remote/4,
 	 reg_or_locate/1, reg_or_locate/2, reg_or_locate/3,
 	 reg_shared/1, reg_shared/2, reg_shared/3, unreg_shared/1,
 	 set_attributes_shared/2, set_value_shared/2,
@@ -91,6 +90,10 @@
          prev/2,
          last/1,
          table/0, table/1, table/2]).
+
+%% Remote API
+-export([reg_remote/2, reg_remote/3, reg_remote/4, unreg_remote/2,
+         set_value_remote/3, update_counter_remote/3]).
 
 %% Environment handling
 -export([get_env/3, get_env/4,
@@ -1146,32 +1149,35 @@ reg_other1({T,l,_} = Key, Pid, Value, As, Op) when is_pid(Pid) ->
             ?THROW_GPROC_ERROR(badarg)
     end.
 
-reg_remote(Key, Pid) ->
-    ?CATCH_GPROC_ERROR(reg_remote1(Key, Pid, reg), [Key, Pid]).
+reg_remote(Node, Key) ->
+    ?CATCH_GPROC_ERROR(reg_remote1(Node, Key, reg), [Node, Key]).
 
-reg_remote(Key, Pid, Value) ->
-    ?CATCH_GPROC_ERROR(reg_remote1(Key, Pid, Value, [], reg), [Key, Pid, Value]).
+reg_remote(Node, Key, Value) ->
+    ?CATCH_GPROC_ERROR(reg_remote1(Node, Key, Value, [], reg), [Node, Key, Value, []]).
 
-reg_remote(Key, Pid, Value, Attrs) ->
-    ?CATCH_GPROC_ERROR(reg_remote1(Key, Pid, Value, Attrs, reg),
-                       [Key, Pid, Value, Attrs]).
+reg_remote(Node, Key, Value, Attrs) ->
+    ?CATCH_GPROC_ERROR(reg_remote1(Node, Key, Value, Attrs, reg),
+                       [Node, Key, Value, Attrs]).
 
-reg_remote1({_,l,_} = Key, Pid, Op) when is_pid(Pid), node(Pid) =/= node() ->
-    reg_remote1(Key, Pid, default(Key), [], Op);
+reg_remote1(Node, {_,l,_} = Key, Op) ->
+    reg_remote1(Node, Key, default(Key), [], Op);
 reg_remote1(_, _, _) ->
     ?THROW_GPROC_ERROR(badarg).
 
-reg_remote1({T,l,_} = Key, Pid, Value, As, Op)
-  when is_pid(Pid), node(Pid) =/= node(), is_list(As) ->
+reg_remote1(Node, {T,l,_} = Key, Value, As, Op)
+  when is_atom(Node), Node =/= node(self()), is_list(As) ->
     if Op == reg; Op == ensure ->
             if T==n; T==p; T==c; T==a; T==r; T==rc ->
-                    call({reg_remote, Key, Pid, Value, As, Op});
+                    call(Node, {reg_remote, Key, Value, As, Op}, l);
                true ->
                     ?THROW_GPROC_ERROR(badarg)
             end;
        true ->
             ?THROW_GPROC_ERROR(badarg)
     end.
+
+unreg_remote(Node, {_,l,_} = Key) ->
+    call(Node, {unreg, Key}, l).
 
 %% @spec reg_or_locate(Key::key(), Value) -> {pid(), NewValue}
 %%
@@ -1528,7 +1534,7 @@ local_reg({_,Scope,_} = Key, Value, As, Op) ->
             case ets:member(?TAB, {Key, self()}) of
                 true when Op == ensure ->
                     gproc_lib:do_set_value(Key, Value, self()),
-                    set_attrs(As, Key, self()),
+                    _ = set_attrs(As, Key, self()),
                     updated;
                 _ ->
                     ?THROW_GPROC_ERROR(badarg)
@@ -1536,7 +1542,7 @@ local_reg({_,Scope,_} = Key, Value, As, Op) ->
         true  ->
             monitor_me(),
             if As =/= [] ->
-                    gproc_lib:insert_attr(Key, As, self(), Scope),
+                    _ = gproc_lib:insert_attr(Key, As, self(), Scope),
                     regged_new(Op);
                true ->
                     regged_new(Op)
@@ -1569,6 +1575,12 @@ local_munreg(T, L) when T==p; T==c ->
 %%
 set_value(Key, Value) ->
     ?CATCH_GPROC_ERROR(set_value1(Key, Value), [Key, Value]).
+
+set_value_remote(Node, Key, Value) when is_atom(Node) ->
+    ?CATCH_GPROC_ERROR(set_value_remote1(Node, Key, Value), [Node, Key, Value]).
+
+set_value_remote1(Node, Key, Value) when is_atom(Node), Node =/= node(self()) ->
+    call(Node, {set, Key, Value}, l).
 
 %% @spec (Key :: key(), Value) -> true
 %% @doc Sets the value of the shared registration given by Key
@@ -1894,6 +1906,12 @@ update_counter1({T,g,_} = Key, Pid, Incr) when T==c; T==r; T==n ->
     gproc_dist:update_counter(Key, Pid, Incr);
 update_counter1(_, _, _) ->
     ?THROW_GPROC_ERROR(badarg).
+
+update_counter_remote(Node, Key, Incr) ->
+    ?CATCH_GPROC_ERROR(update_counter_remote1(Node, Key, Incr), [Node, Key, Incr]).
+
+update_counter_remote1(Node, Key, Incr) when Node =/= node(self()) ->
+    call(Node, {update_counter_remote, Key, Incr}, l).
 
 %% @doc Update a list of counters
 %%
@@ -2319,7 +2337,7 @@ handle_call({reg, {_T,l,_} = Key, Val, Attrs, Op}, {Pid,_}, S) ->
     handle_reg_call(Key, Pid, Val, Attrs, Op, S);
 handle_call({reg_other, {_T,l,_} = Key, Pid, Val, Attrs, Op}, _, S) ->
     handle_reg_call(Key, Pid, Val, Attrs, Op, S);
-handle_call({reg_remote, {_T,l,_} = Key, Pid, Val, Attrs, Op}, _, S) ->
+handle_call({reg_remote, {_T,l,_} = Key, Val, Attrs, Op}, {Pid,_}, S) ->
     handle_reg_call(Key, Pid, Val, Attrs, Op, S);
 handle_call({set_attributes, {_,l,_} = Key, Attrs}, {Pid,_}, S) ->
     case gproc_lib:insert_attr(Key, Attrs, Pid, l) of
@@ -2333,6 +2351,14 @@ handle_call({set_attributes_shared, {_,l,_} = Key, Attrs}, _, S) ->
 	    {reply, badarg, S};
 	L when is_list(L) ->
 	    {reply, true, S}
+    end;
+handle_call({update_counter_remote, Key, Incr}, {Pid,_}, S) ->
+    try gproc_lib:update_counter(Key, Incr, Pid) of
+        Res ->
+            {reply, Res, S}
+    catch
+        error:_ ->
+            {reply, badarg, S}
     end;
 handle_call({reg_or_locate, {T,l,_} = Key, Val, P}, _, S) ->
     Reg = fun() ->

--- a/src/gproc_dist.erl
+++ b/src/gproc_dist.erl
@@ -389,7 +389,7 @@ handle_leader_call({Reg, {_C,g,_Name} = K, Value, Pid, As, Op}, _From, S, _E)
             case ets:lookup(?TAB, ets_key(K, Pid)) of
                 [{_, Pid, _}] ->
                     gproc_lib:do_set_value(K, Value, Pid),
-                    gproc_lib:insert_attr(K, As, Pid, g),
+                    _ = gproc_lib:insert_attr(K, As, Pid, g),
                     Vals = mk_broadcast_insert_vals([{K, Pid, Value}]),
                     {reply, updated, [{insert, Vals}], S};
                 _ ->
@@ -893,14 +893,14 @@ insert_globals(Globals) ->
       fun({{{_,_,_} = Key,_}, Pid, _} = Obj, A) ->
               ets:insert(?TAB, Obj),
 	      ets:insert_new(?TAB, {{Pid,Key}, []}),
-	      gproc_lib:ensure_monitor(Pid,g),
+	      _ = gproc_lib:ensure_monitor(Pid,g),
 	      A;
          ({{{_,_,_},_}, _} = Obj, A) ->
               ets:insert(?TAB, Obj),
               A;
          ({{P,_K}, Opts} = Obj, A) when is_pid(P), is_list(Opts) ->
 	      ets:insert(?TAB, Obj),
-	      gproc_lib:ensure_monitor(P,g),
+	      _ = gproc_lib:ensure_monitor(P,g),
 	      [Obj] ++ A;
 	 (_Other, A) ->
 	      A

--- a/src/gproc_pool.erl
+++ b/src/gproc_pool.erl
@@ -99,6 +99,8 @@
 
 -record(st, {}).
 
+-dialyzer({nowarn_function, ptest/4}).
+
 %% @spec new(Pool::any()) -> ok
 %%
 %% @equiv new(Pool, round_robin, [])
@@ -745,7 +747,7 @@ force_delete_(Pool) ->
       fun({Key, Pid, _}) when Pid == self() -> gproc:unreg(Key);
          ({_, Pid, _}) when is_pid(Pid) -> exit(Pid, kill)
       end, Names),
-    [gproc:unreg_shared(W) || {W,shared,_} <- Cur ++ Props ++ Workers],
+    _ = [gproc:unreg_shared(W) || {W,shared,_} <- Cur ++ Props ++ Workers],
     true.
 
 find_names(Pool, Pid) ->
@@ -992,7 +994,7 @@ test(N, Type, Opts) when Type==round_robin;
                          Type==direct;
                          Type==claim ->
     P = ?LINE,
-    setup_test_pool(P, Type, Opts),
+    _ = setup_test_pool(P, Type, Opts),
     try timer:tc(?MODULE, f(Type), [N, P])
     after
         remove_test_pool(P)
@@ -1000,7 +1002,7 @@ test(N, Type, Opts) when Type==round_robin;
 
 ptest(N, I, Type, Opts) ->
     P = ?LINE,
-    setup_test_pool(P, Type, Opts),
+    _ = setup_test_pool(P, Type, Opts),
     F = f(Type),
     Pids =
         [spawn_monitor(fun() -> exit({ok, timer:tc(?MODULE, F, [I, P])}) end)
@@ -1053,9 +1055,9 @@ remove_test_pool(P) ->
                             {l,c},
                             [{ {{c,l,{?MODULE,P,w,'$1'}},'_','$2'}, [],
                                [{{'$1','$2'}}] }])]),
-    [begin disconnect_worker(P, W),
-           remove_worker(P, W)
-     end || W <- test_workers()],
+    _ = [begin disconnect_worker(P, W),
+               remove_worker(P, W)
+         end || W <- test_workers()],
     delete(P).
 
 test_workers() -> [a,b,c,d,e,f].

--- a/src/gproc_ps.erl
+++ b/src/gproc_ps.erl
@@ -135,6 +135,8 @@ subscribe_cond(Scope, Event, Spec) when Scope==l; Scope==g ->
     gproc:reg({p,Scope,{?ETag, Event}}, Spec).
 
 -spec subscribe_cond_remote(node(), event(), cond_spec()) -> true.
+%% @doc Subscribe conditionally from a remote node
+%% @end
 subscribe_cond_remote(Node, Event, Spec) when is_atom(Node) ->
     _ = case Spec of
             undefined -> ok;
@@ -159,6 +161,8 @@ change_cond(Scope, Event, Spec) when Scope==l; Scope==g ->
     gproc:set_value({p,Scope,{?ETag, Event}}, Spec).
 
 -spec change_cond_remote(node(), event(), cond_spec()) -> true.
+%% @doc Change the condition spec of a subscription created from a remote node
+%% @end
 change_cond_remote(Node, Event, Spec) ->
     _ = validate_spec(Spec),
     gproc:set_value_remote(Node, {p,l,{?ETag, Event}}, Spec).
@@ -171,7 +175,7 @@ validate_spec(Spec) ->
     end.
 
 -spec unsubscribe(scope(), event()) -> true.
-%% @doc Remove subscribtion created using `subscribe(Scope, Event)'
+%% @doc Remove subscription created using `subscribe(Scope, Event)'
 %%
 %% This removes the property created through `subscribe/2'.
 %% @end
@@ -179,6 +183,8 @@ unsubscribe(Scope, Event) when Scope==l; Scope==g ->
     gproc:unreg({p,Scope,{?ETag, Event}}).
 
 -spec unsubscribe_remote(node(), event()) -> true.
+%% @doc Remove subscription created from a remote node
+%% @end
 unsubscribe_remote(Node, Event) ->
     gproc:unreg_remote(Node, {p, l, {?ETag, Event}}).
 
@@ -292,16 +298,28 @@ enable_single(Scope, Event) when Scope==l; Scope==g ->
     [Prev,1] = gproc:update_counter({c,Scope,{?ETag,Event}}, [0, {1, 1, 1}]),
     Prev.
 
+-spec create_single_remote(node(), event()) -> true.
+%% @doc Create a local single-shot subscription from a remote node
+%% @end
 create_single_remote(Node, Event) ->
     gproc:reg_remote(Node, {c,l,{?ETag, Event}}, 1).
 
+-spec delete_single_remote(node(), event()) -> true.
+%% @doc Delete a single-shot subscription created from a remote node
+%% @end
 delete_single_remote(Node, Event) ->
     gproc:unreg_remote(Node, {c,l,{?ETag, Event}}).
 
+-spec disable_single_remote(node(), event()) -> status().
+%% @doc Disable a single-shot subscription created from a remote node
+%% @end
 disable_single_remote(Node, Event) ->
     [Prev,0] = gproc:update_counter_remote(Node, {c,l,{?ETag,Event}}, [0, {-1,0,0}]),
     Prev.
 
+-spec enable_single_remote(node(), event()) -> status().
+%% @doc Enable a single-shot subscription created from a remote node
+%% @end
 enable_single_remote(Node, Event) ->
     [Prev,1] = gproc:update_counter_remote(Node, {c,l,{?ETag,Event}}, [0, {1,1,1}]),
     Prev.

--- a/test/gproc_remote_tests.erl
+++ b/test/gproc_remote_tests.erl
@@ -1,0 +1,122 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% --------------------------------------------------
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%% --------------------------------------------------
+%%
+%% @author Ulf Wiger <ulf@wiger.net>
+%%
+-module(gproc_remote_tests).
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+-define(t(E), ?_test(?debugVal(E))).
+
+remote_test_() ->
+    %% dbg:tracer(),
+    %% dbg:tpl(?MODULE,x),
+    %% dbg:tpl(gproc_test_lib,x),
+    %% dbg:tp(slave,x),
+    %% dbg:p(all,[c]),
+    StartedNet = gproc_test_lib:ensure_dist(),
+    N = gproc_test_lib:node_name(remote_n1),
+    {setup,
+     fun() ->
+             gproc_test_lib:start_node(N),
+             rpc:call(N, application, start, [gproc]),
+             N
+     end,
+     fun(Node) ->
+             gproc_test_lib:stop_node(Node),
+             case StartedNet of
+                 true ->
+                     net_kernel:stop();
+                 false ->
+                     ok
+             end
+     end,
+     [
+      ?t(t_remote_reg_name(N)),
+      ?t(t_remote_reg_prop(N)),
+      ?t(t_pub_sub(N)),
+      ?t(t_single(N))
+     ]}.
+
+%% remote_setup() ->
+%%     gproc_test_lib:start_node(remote_n1).
+
+%% remote_cleanup(N) ->
+%%     gproc_test_lib:stop_node(N).
+
+t_remote_reg_name(N) ->
+    Key = {n,l,the_remote_name},
+    true = gproc:reg_remote(N, Key),
+    Me = self(),
+    Me = rpc:call(N, gproc, where, [Key]),
+    true = gproc:unreg_remote(N, Key),
+    undefined = rpc:call(N, gproc, where, [Key]),
+    ok.
+
+t_remote_reg_prop(N) ->
+    Key = {p, l, the_remote_prop},
+    true = gproc:reg_remote(N, Key),
+    Me = self(),
+    [Me] = rpc:call(N, gproc, lookup_pids, [Key]),
+    true = gproc:unreg_remote(N, Key),
+    [] = rpc:call(N, gproc, lookup_pids, [Key]),
+    ok.
+
+t_pub_sub(N) ->
+    true = gproc_ps:subscribe_remote(N, my_event),
+    Msg = rpc:call(N, gproc_ps, publish, [l, my_event, foo]),
+    receive
+        Msg ->
+            ok
+    after 1000 ->
+            error(timeout)
+    end,
+    true = gproc_ps:unsubscribe_remote(N, my_event),
+    Msg2 = rpc:call(N, gproc_ps, publish, [my_event, foo2]),
+    receive
+        Msg2 ->
+            error(unsub_failed)
+    after 100 ->
+            ok
+    end.
+
+t_single(N) ->
+    Me = self(),
+    true = gproc_ps:create_single_remote(N, my_single),
+    [Me] = rpc:call(N, gproc_ps, tell_singles, [l, my_single, foo1]),
+    receive
+        {gproc_ps_event, my_single, foo1} -> ok
+    after 1000 -> error(timeout)
+    end,
+    [] = rpc:call(N, gproc_ps, tell_singles, [l, my_single, foo2]),
+    0 = gproc_ps:enable_single_remote(N, my_single),
+    [Me] = rpc:call(N, gproc_ps, tell_singles, [l, my_single, foo3]),
+    receive
+        {gproc_ps_event, my_single, foo3} -> ok
+    after 1000 -> error(enable_single_failed)
+    end,
+    0 = gproc_ps:enable_single_remote(N, my_single),
+    1 = gproc_ps:disable_single_remote(N, my_single),
+    [] = rpc:call(N, gproc_ps, tell_singles, [l, my_single, foo4]),
+    true = gproc_ps:delete_single_remote(N, my_single),
+    true = gproc_ps:create_single_remote(N, my_single),
+    true = gproc_ps:delete_single_remote(N, my_single),
+    ok.
+
+-endif.


### PR DESCRIPTION
First sketch of remote registration and `gproc_ps` subscriptions.

The idea is that registering remote pids shouldn't be a problem in itself, but all regs must go through the gproc server, can only have local scope, and the API function should be distinctly only for non-local pids.

**TODO:** add `ensure_...` and `unreg` functions etc. as well as test cases.