### PR TITLE
Fix issue #172

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ script: "GPROC_DIST=true rebar get-deps compile eunit"
 otp_release:
     - 20.0
     - 19.3
-    - 19.2
-    - 19.1
     - 19.0
     - 18.3
     - 18.2.1

--- a/src/gproc.erl
+++ b/src/gproc.erl
@@ -2358,7 +2358,7 @@ handle_call({demonitor, {T,l,_} = Key, Ref, Pid}, _From, S)
                     [{K, Opts}] ->
                         Opts1 = gproc_lib:remove_monitor(Opts, Pid, Ref),
                         ets:insert(?TAB, {K, Opts1}),
-                        case gproc_lib:does_pid_monitor(Pid, Opts) of
+                        case gproc_lib:does_pid_monitor(Pid, Opts1) of
                             true ->
                                 ok;
                             false ->

--- a/src/gproc_lib.erl
+++ b/src/gproc_lib.erl
@@ -291,13 +291,13 @@ remove_monitors(Key, Pid, MPid) ->
 	[{_, r}] ->
 	    [];
 	[{K, Opts}] when is_list(Opts) ->
-	    case lists:keyfind(monitors, 1, Opts) of
+	    case lists:keyfind(monitor, 1, Opts) of
 		false ->
 		    [];
 		{_, Ms} ->
-		    Ms1 = [{P,R} || {P,R} <- Ms,
+		    Ms1 = [{P,R,T} || {P,R,T} <- Ms,
 				    P =/= MPid],
-		    NewMs = lists:keyreplace(monitors, 1, Opts, {monitors,Ms1}),
+		    NewMs = lists:keyreplace(monitor, 1, Opts, {monitor,Ms1}),
 		    ets:insert(?TAB, {K, NewMs}),
 		    [{insert, [{{Pid,Key}, NewMs}]}]
 	    end;
@@ -306,7 +306,7 @@ remove_monitors(Key, Pid, MPid) ->
     end.
 
 does_pid_monitor(Pid, Opts) ->
-    case lists:keyfind(monitors, 1, Opts) of
+    case lists:keyfind(monitor, 1, Opts) of
         false ->
             false;
         {_, Ms} ->
@@ -393,7 +393,7 @@ select_monitors([], _, Acc) ->
     Acc.
 
 remove_monitor_pid([{monitor, Mons}|T], Pid) ->
-    [{monitors, [M || M <- Mons,
+    [{monitor, [M || M <- Mons,
                       element(1, M) =/= Pid]}|T];
 remove_monitor_pid([H|T], Pid) ->
     [H | remove_monitor_pid(T, Pid)];


### PR DESCRIPTION
Got rid of a mess with 'monitor'/'monitor[s]' tags in the ETS table
The only 'monitor' tag is used now and that fixes issue #172
Appropriate unit test added

Note:
According to https://docs.travis-ci.com/user/languages/erlang/ Erlang OTP releleases 19.1 and 19.2 aren't supported and should be removed from the Travis configuration file

