### PR TITLE
Improved support for 'r' objects

### DIFF
--- a/src/gproc.erl
+++ b/src/gproc.erl
@@ -360,7 +360,7 @@ lookup_global_counters(P)   -> lookup_values({c,g,P}).
 %%
 %% @doc Look up all local (non-unique) instances of a given Resource.
 %% Returns a list of {Pid, Value} tuples for all matching objects.
-%% @equiv lookup_values({c, l, Resource})
+%% @equiv lookup_values({r, l, Resource})
 %% @end
 %%
 lookup_local_resources(P)    -> lookup_values({r,l,P}).
@@ -370,7 +370,7 @@ lookup_local_resources(P)    -> lookup_values({r,l,P}).
 %%
 %% @doc Look up all global (non-unique) instances of a given Resource.
 %% Returns a list of {Pid, Value} tuples for all matching objects.
-%% @equiv lookup_values({c, g, Resource})
+%% @equiv lookup_values({r, g, Resource})
 %% @end
 %%
 lookup_global_resources(P)   -> lookup_values({r,g,P}).

--- a/src/gproc.erl
+++ b/src/gproc.erl
@@ -1849,10 +1849,10 @@ lookup_values({T,_,_} = Key) ->
 -spec update_counter(key(), increment()) -> integer() | [integer()].
 update_counter(Key, Incr) ->
     Pid = case Key of
-	      {n,_,_} -> n;
-	      {T,_,_} when T==c; T==r ->
+              {n,_,_} -> n;
+              {T,_,_} when T==c; T==r ->
                   self()
-	  end,
+          end,
     ?CATCH_GPROC_ERROR(update_counter1(Key, Pid, Incr), [Key, Incr]).
 
 update_counter(Key, Pid, Incr) when is_pid(Pid);
@@ -2329,10 +2329,10 @@ handle_call({monitor, {T,l,_} = Key, Pid, Type}, _From, S)
     Lookup = ets:lookup(?TAB, {Key, T}),
     IsRegged = is_regged(Lookup),
     _ = case {IsRegged, Type} of
-	    {false, info} ->
-		Pid ! {gproc, unreg, Ref, Key};
+            {false, info} ->
+                Pid ! {gproc, unreg, Ref, Key};
             {false, follow} ->
-		Pid ! {gproc, unreg, Ref, Key},
+                Pid ! {gproc, unreg, Ref, Key},
                 _ = gproc_lib:ensure_monitor(Pid, l),
                 case Lookup of
                     [{K, Waiters}] ->
@@ -2348,19 +2348,19 @@ handle_call({monitor, {T,l,_} = Key, Pid, Type}, _From, S)
                 true = gproc_lib:insert_reg(Key, undefined, Pid, l, Evt),
                 Pid ! {gproc, Evt, Ref, Key},
                 _ = gproc_lib:ensure_monitor(Pid, l);
-	    {true, _} ->
+            {true, _} ->
                 [{_, RegPid, _}] = Lookup,
                 _ = gproc_lib:ensure_monitor(Pid, l),
-		case ets:lookup(?TAB, {RegPid, Key}) of
-		    [{K,r}] ->
-			ets:insert(?TAB, {K, [{monitor, [{Pid,Ref,Type}]}]}),
+                case ets:lookup(?TAB, {RegPid, Key}) of
+                    [{K,r}] ->
+                        ets:insert(?TAB, {K, [{monitor, [{Pid,Ref,Type}]}]}),
                         ets:insert_new(?TAB, {{Pid,Key}, []});
-		    [{K, Opts}] ->
-			ets:insert(?TAB, {K, gproc_lib:add_monitor(
+                    [{K, Opts}] ->
+                        ets:insert(?TAB, {K, gproc_lib:add_monitor(
                                                Opts, Pid, Ref, Type)}),
                         ets:insert_new(?TAB, {{Pid,Key}, []})
-		end
-	end,
+                end
+        end,
     {reply, Ref, S};
 handle_call({demonitor, {T,l,_} = Key, Ref, Pid}, _From, S)
   when T==n; T==a; T==rc ->
@@ -3106,24 +3106,24 @@ remove_dead(true, Objs) ->
 %% a test case that verifies the difference between having the option and not.
 qlc_lookup_pid(Pid, Scope, Check) ->
     case Check andalso ?PID_IS_DEAD(Pid) of
-	true ->
-	    [];
-	false ->
-	    Found =
-		ets:select(?TAB, [{{{Pid, rev_keypat(Scope)}, '_'},
-				   [], ['$_']}]),
-	    lists:flatmap(
-	      fun({{_,{T,_,_}=K}, _}) ->
-		      K2 = if T==n orelse T==a orelse T==rc -> T;
-			      true -> Pid
-			   end,
-		      case ets:lookup(?TAB, {K,K2}) of
-			  [{{Key,_},_,Value}] ->
-			      [{Key, Pid, Value}];
-			  [] ->
-			      []
-		      end
-	      end, Found)
+        true ->
+            [];
+        false ->
+            Found =
+                ets:select(?TAB, [{{{Pid, rev_keypat(Scope)}, '_'},
+                                   [], ['$_']}]),
+            lists:flatmap(
+              fun({{_,{T,_,_}=K}, _}) ->
+                      K2 = if T==n orelse T==a orelse T==rc -> T;
+                              true -> Pid
+                           end,
+                      case ets:lookup(?TAB, {K,K2}) of
+                          [{{Key,_},_,Value}] ->
+                              [{Key, Pid, Value}];
+                          [] ->
+                              []
+                      end
+              end, Found)
     end.
 
 

--- a/src/gproc_lib.erl
+++ b/src/gproc_lib.erl
@@ -529,7 +529,8 @@ do_set_counter_value({_,C,N} = Key, Value, Pid) ->
     Res.
 
 update_counter({T,l,Ctr} = Key, Incr, Pid) when is_integer(Incr), T==c;
-						is_integer(Incr), T==n ->
+						is_integer(Incr), T==r;
+                                                is_integer(Incr), T==n ->
     Res = ets:update_counter(?TAB, {Key, Pid}, {3,Incr}),
     if T==c ->
 	    update_aggr_counter(l, Ctr, Incr);
@@ -539,6 +540,7 @@ update_counter({T,l,Ctr} = Key, Incr, Pid) when is_integer(Incr), T==c;
     Res;
 update_counter({T,l,Ctr} = Key, {Incr, Threshold, SetValue}, Pid)
   when is_integer(Incr), is_integer(Threshold), is_integer(SetValue), T==c;
+       is_integer(Incr), is_integer(Threshold), is_integer(SetValue), T==r;
        is_integer(Incr), is_integer(Threshold), is_integer(SetValue), T==n ->
     [Prev, New] = ets:update_counter(?TAB, {Key, Pid},
 				     [{3, 0}, {3, Incr, Threshold, SetValue}]),

--- a/src/gproc_lib.erl
+++ b/src/gproc_lib.erl
@@ -46,7 +46,7 @@
          update_aggr_counter/3,
          update_counter/3,
          decrement_resource_count/2,
-	   valid_opts/2,
+         valid_opts/2,
          valid_key/1]).
 
 -export([dbg/1]).
@@ -529,13 +529,13 @@ do_set_counter_value({_,C,N} = Key, Value, Pid) ->
     Res.
 
 update_counter({T,l,Ctr} = Key, Incr, Pid) when is_integer(Incr), T==c;
-						is_integer(Incr), T==r;
+                                                is_integer(Incr), T==r;
                                                 is_integer(Incr), T==n ->
     Res = ets:update_counter(?TAB, {Key, Pid}, {3,Incr}),
     if T==c ->
-	    update_aggr_counter(l, Ctr, Incr);
+            update_aggr_counter(l, Ctr, Incr);
        true ->
-	    ok
+            ok
     end,
     Res;
 update_counter({T,l,Ctr} = Key, {Incr, Threshold, SetValue}, Pid)
@@ -543,28 +543,28 @@ update_counter({T,l,Ctr} = Key, {Incr, Threshold, SetValue}, Pid)
        is_integer(Incr), is_integer(Threshold), is_integer(SetValue), T==r;
        is_integer(Incr), is_integer(Threshold), is_integer(SetValue), T==n ->
     [Prev, New] = ets:update_counter(?TAB, {Key, Pid},
-				     [{3, 0}, {3, Incr, Threshold, SetValue}]),
+                                     [{3, 0}, {3, Incr, Threshold, SetValue}]),
     if T==c ->
-	    update_aggr_counter(l, Ctr, New - Prev);
+            update_aggr_counter(l, Ctr, New - Prev);
        true ->
-	    ok
+            ok
     end,
     New;
 update_counter({T,l,Ctr} = Key, Ops, Pid) when is_list(Ops), T==c;
                                                is_list(Ops), T==r;
-					       is_list(Ops), T==n ->
+                                               is_list(Ops), T==n ->
     case ets:update_counter(?TAB, {Key, Pid},
-			    [{3, 0} | expand_ops(Ops)]) of
-	[_] ->
-	    [];
-	[Prev | Rest] ->
-	    [New | _] = lists:reverse(Rest),
-	    if T==c ->
-		    update_aggr_counter(l, Ctr, New - Prev);
-	       true ->
-		    ok
-	    end,
-	    Rest
+                            [{3, 0} | expand_ops(Ops)]) of
+        [_] ->
+            [];
+        [Prev | Rest] ->
+            [New | _] = lists:reverse(Rest),
+            if T==c ->
+                    update_aggr_counter(l, Ctr, New - Prev);
+               true ->
+                    ok
+            end,
+            Rest
     end;
 update_counter(_, _, _) ->
     ?THROW_GPROC_ERROR(badarg).

--- a/test/gproc_dist_tests.erl
+++ b/test/gproc_dist_tests.erl
@@ -419,9 +419,11 @@ t_update_counters(C1, C12, C2, [H1,H2|_] = Ns) ->
        true -> ok
     end,
     ?assertMatch([{C1,P1, 3},
-		  {C12,P12,4},
-		  {C2,P2, 0}], t_call(P1, {apply, gproc, update_counters,
-					   [g, [{C1,P1,1},{C12,P12,2},{C2,P2,{-2,0,0}}]]})),
+                  {C12,P12,4},
+                  {C2,P2, 0}], t_call(P1, {apply, gproc, update_counters,
+                                           [g, [ {C1,P1,1}
+                                               , {C12,P12,2}
+                                               , {C2,P2,{-2,0,0}} ]]})),
     ?assertMatch(ok, t_read_everywhere(C1, P1, Ns, 3)),
     ?assertMatch(ok, t_read_everywhere(C12, P12, Ns, 4)),
     ?assertMatch(ok, t_read_everywhere(C2, P2, Ns, 0)),

--- a/test/gproc_dist_tests.erl
+++ b/test/gproc_dist_tests.erl
@@ -70,6 +70,8 @@ basic_tests(Ns) ->
      ?f(t_simple_ensure_other(Ns)),
      ?f(t_simple_reg_or_locate(Ns)),
      ?f(t_simple_counter(Ns)),
+     ?f(t_simple_r_counter(Ns)),
+     ?f(t_simple_n_counter(Ns)),
      ?f(t_aggr_counter(Ns)),
      ?f(t_awaited_aggr_counter(Ns)),
      ?f(t_simple_resource_count(Ns)),
@@ -78,6 +80,8 @@ basic_tests(Ns) ->
      ?f(t_awaited_resource_count(Ns)),
      ?f(t_resource_count_on_zero(Ns)),
      ?f(t_update_counters(Ns)),
+     ?f(t_update_r_counters(Ns)),
+     ?f(t_update_n_counters(Ns)),
      ?f(t_shared_counter(Ns)),
      ?f(t_prop(Ns)),
      ?f(t_mreg(Ns)),
@@ -216,6 +220,22 @@ t_simple_counter([H|_] = Ns) ->
     ?assertMatch(ok, t_read_everywhere(Ctr, P, Ns, 5)),
     ?assertMatch(ok, t_call(P, die)).
 
+t_simple_r_counter([H|_] = Ns) ->
+    Ctr = ?T_RESOURCE,
+    P = t_spawn_reg(H, Ctr, 3),
+    ?assertMatch(ok, t_read_everywhere(Ctr, P, Ns, 3)),
+    ?assertMatch(5, t_call(P, {apply, gproc, update_counter, [Ctr, 2]})),
+    ?assertMatch(ok, t_read_everywhere(Ctr, P, Ns, 5)),
+    ?assertMatch(ok, t_call(P, die)).
+
+t_simple_n_counter([H|_] = Ns) ->
+    Ctr = ?T_NAME,
+    P = t_spawn_reg(H, Ctr, 3),
+    ?assertMatch(ok, t_read_everywhere(Ctr, P, Ns, 3)),
+    ?assertMatch(5, t_call(P, {apply, gproc, update_counter, [Ctr, 2]})),
+    ?assertMatch(ok, t_read_everywhere(Ctr, P, Ns, 5)),
+    ?assertMatch(ok, t_call(P, die)).
+
 t_shared_counter([H|_] = Ns) ->
     Ctr = ?T_COUNTER,
     P = t_spawn_reg_shared(H, Ctr, 3),
@@ -319,7 +339,6 @@ t_wild_key_in_resource([H1|_]) ->
     ?assertError({'DOWN', _, {badarg, _}},
                  t_call(P2, {apply, gproc, mreg, [r, g, [{Rw, 1}]]})).
 
-
 t_awaited_resource_count([H1,H2|_] = Ns) ->
     {r,g,Nm} = R = ?T_RESOURCE,
     RC = {rc,g,Nm},
@@ -368,29 +387,53 @@ t_resource_count_on_zero([H1,H2|_] = Ns) ->
     ?assertMatch(ok, t_call(Pp, die)),
     ?assertMatch(ok, t_call(Prc, die)).
 
-t_update_counters([H1,H2|_] = Ns) ->
-    {c,g,N1} = C1 = ?T_COUNTER,
-    A1 = {a,g,N1},
+t_update_counters(Ns) ->
+    C1 = ?T_COUNTER,
     C2 = ?T_COUNTER,
+    t_update_counters(C1, C1, C2, Ns).
+
+t_update_r_counters(Ns) ->
+    C1 = ?T_RESOURCE,
+    C2 = ?T_RESOURCE,
+    t_update_counters(C1, C1, C2, Ns).
+
+t_update_n_counters(Ns) ->
+    C1 = ?T_NAME,
+    C2 = ?T_NAME,
+    C3 = ?T_NAME,
+    t_update_counters(C1, C2, C3, Ns).
+
+t_update_counters(C1, C12, C2, [H1,H2|_] = Ns) ->
+    {T,g,N1} = C1,
+    A1 = {a,g,N1},
     P1 = t_spawn_reg(H1, C1, 2),
-    P12 = t_spawn_reg(H2, C1, 2),
+    P12 = t_spawn_reg(H2, C12, 2),
     P2 = t_spawn_reg(H2, C2, 1),
-    Pa1 = t_spawn_reg(H2, A1),
+    Pa1 = if T==c -> t_spawn_reg(H2, A1);
+             true -> undefined
+          end,
     ?assertMatch(ok, t_read_everywhere(C1, P1, Ns, 2)),
-    ?assertMatch(ok, t_read_everywhere(C1, P12, Ns, 2)),
+    ?assertMatch(ok, t_read_everywhere(C12, P12, Ns, 2)),
     ?assertMatch(ok, t_read_everywhere(C2, P2, Ns, 1)),
-    ?assertMatch(ok, t_read_everywhere(A1, Pa1, Ns, 4)),
+    if T==c -> ?assertMatch(ok, t_read_everywhere(A1, Pa1, Ns, 4));
+       true -> ok
+    end,
     ?assertMatch([{C1,P1, 3},
-		  {C1,P12,4},
+		  {C12,P12,4},
 		  {C2,P2, 0}], t_call(P1, {apply, gproc, update_counters,
-					   [g, [{C1,P1,1},{C1,P12,2},{C2,P2,{-2,0,0}}]]})),
+					   [g, [{C1,P1,1},{C12,P12,2},{C2,P2,{-2,0,0}}]]})),
     ?assertMatch(ok, t_read_everywhere(C1, P1, Ns, 3)),
-    ?assertMatch(ok, t_read_everywhere(C1, P12, Ns, 4)),
+    ?assertMatch(ok, t_read_everywhere(C12, P12, Ns, 4)),
     ?assertMatch(ok, t_read_everywhere(C2, P2, Ns, 0)),
-    ?assertMatch(ok, t_read_everywhere(A1, Pa1, Ns, 7)),
+    if T==c -> ?assertMatch(ok, t_read_everywhere(A1, Pa1, Ns, 7));
+       true -> ok
+    end,
     ?assertMatch(ok, t_call(P1, die)),
     ?assertMatch(ok, t_call(P12, die)),
-    ?assertMatch(ok, t_call(P2, die)).
+    ?assertMatch(ok, t_call(P2, die)),
+    if T==c -> ?assertMatch(ok, t_call(Pa1, die));
+       true -> ok
+    end.
 
 t_prop([H1,H2|_] = Ns) ->
     {p, g, _} = P = ?T_PROP,

--- a/test/gproc_tests.erl
+++ b/test/gproc_tests.erl
@@ -108,6 +108,10 @@ reg_test_() ->
       , ?_test(t_is_clean())
       , {spawn, ?_test(?debugVal(t_update_counters()))}
       , ?_test(t_is_clean())
+      , {spawn, ?_test(?debugVal(t_update_r_counter()))}
+      , ?_test(t_is_clean())
+      , {spawn, ?_test(?debugVal(t_update_n_counter()))}
+      , ?_test(t_is_clean())
       , {spawn, ?_test(?debugVal(t_simple_prop()))}
       , ?_test(t_is_clean())
       , {spawn, ?_test(?debugVal(t_await()))}
@@ -446,6 +450,17 @@ t_update_counters() ->
     end,
     ?assert(gproc:get_value({a,l,c1}) =:= 7).
 
+t_update_r_counter() ->
+    K = {r,l,r1},
+    ?assert(gproc:reg(K, 3) =:= true),
+    ?assertEqual(5, gproc:update_counter(K, 2)),
+    ?assert(gproc:get_value(K) =:= 5).
+
+t_update_n_counter() ->
+    K = {n,l,n1},
+    ?assert(gproc:reg(K, 3) =:= true),
+    ?assertEqual(5, gproc:update_counter(K, 2)),
+    ?assert(gproc:get_value(K) =:= 5).
 
 t_simple_prop() ->
     ?assert(gproc:reg({p,l,prop}) =:= true),


### PR DESCRIPTION
See PR #163 

Support for resource objects ('r') is made more general, and various inconsistencies around `update_counter()` have been fixed, making it possible to use both names and resources as counters.

Test cases added