### PR TITLE
Fix SPDX license ID

### DIFF
--- a/src/gproc.app.src
+++ b/src/gproc.app.src
@@ -12,7 +12,7 @@
   {mod, {gproc_app, []} },
 
   {maintainers, ["Ulf Wiger"]},
-  {licenses, ["APL 2.0"]},
+  {licenses, ["Apache-2.0"]},
   {links, [{"Github", "https://github.com/uwiger/gproc"}]}
  ]
 }.


### PR DESCRIPTION
"APL" is "Adaptive Public License" (and there is only a 1.0, no 2.0). The LICENSE file in the repo is "Apache License 2.0", which has SPDX license ID "Apache-2.0".