### PR TITLE
Support multiple clauses in select() match specs

### DIFF
--- a/patches/stdlib/gen_server.erl
+++ b/patches/stdlib/gen_server.erl
@@ -797,7 +797,7 @@ format_status(Opt, StatusData) ->
 	      end,
     Header = lists:concat(["Status for generic server ", NameTag]),
     Log = sys:get_debug(log, Debug, []),
-    Specific = 
+    Specific =
 	case erlang:function_exported(Mod, format_status, 2) of
 	    true ->
 		case catch Mod:format_status(Opt, [PDict, State]) of

--- a/src/gproc.erl
+++ b/src/gproc.erl
@@ -2895,17 +2895,18 @@ monitor_me() ->
     end.
 
 
+pattern(L, Ctxt) when is_list(L) ->
+    [pattern_(P, Ctxt) || P <- L].
 
-
-pattern([{'_', Gs, As}], T) ->
+pattern_({'_', Gs, As}, T) ->
     ?l,
     {HeadPat, Vs} = headpat(T, '$1', '$2', '$3'),
-    [{HeadPat, rewrite(Gs,Vs), rewrite(As,Vs)}];
-pattern([{{A,B,C},Gs,As}], Scope) ->
+    {HeadPat, rewrite(Gs,Vs), rewrite(As,Vs)};
+pattern_({{A,B,C},Gs,As}, Scope) ->
     ?l,
     {HeadPat, Vars} = headpat(Scope, A,B,C),
-    [{HeadPat, rewrite(Gs,Vars), rewrite(As,Vars)}];
-pattern([{Head, Gs, As}], Scope) ->
+    {HeadPat, rewrite(Gs,Vars), rewrite(As,Vars)};
+pattern_({Head, Gs, As}, Scope) ->
     ?l,
     {S, T} = get_s_t(Scope),
     case is_var(Head) of
@@ -2914,7 +2915,7 @@ pattern([{Head, Gs, As}], Scope) ->
             Vs = [{Head, obj_prod()}],
             %% the headpat function should somehow verify that Head is
             %% consistent with Scope (or should we add a guard?)
-            [{HeadPat, rewrite(Gs, Vs), rewrite(As, Vs)}];
+            {HeadPat, rewrite(Gs, Vs), rewrite(As, Vs)};
         false ->
             erlang:error(badarg)
     end.


### PR DESCRIPTION
`gproc:select()` et al match spec processing only supported single-pattern match specs.
This PR removes that limitation.